### PR TITLE
Update config to have optional user/pass

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -18,9 +18,7 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'host',
-    'port',
-    'user',
-    'password'
+    'port'
 ]
 
 
@@ -301,8 +299,8 @@ def main_impl():
 
     client =  MongoClient(host=config['host'],
                           port=int(config['port']),
-                          username=config['user'],
-                          password=config['password'],
+                          username=config.get('user', None),
+                          password=config.get('password', None),
                           authSource=config['dbname'])
 
     if args.discover:


### PR DESCRIPTION
Fix https://github.com/singer-io/tap-mongodb/issues/1

`user`/`pass` in `config.json` should be optional because access control is optional.

> By default mongodb has no enabled access control, so there is no default user or password.
>
> https://stackoverflow.com/a/38921949/796832

Here are some other docs on enabled access control, https://docs.mongodb.com/manual/tutorial/enable-authentication/