### PR TITLE
Updates & Bug Fixes

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -19,10 +19,55 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     'host',
-    'port'
+    'port',
+    'user',
+    'password',
+    'database'
 ]
 
 IGNORE_DBS = ['admin', 'system', 'local', 'config']
+
+def get_databases(client, config):
+
+    # usersInfo Command returns object in shape:
+    # {
+    #     <some_other_keys>
+    #     'users': [
+    #         {
+    #             '_id': <auth_db>.<user>,
+    #             'db': <auth_db>,
+    #             'mechanisms': ['SCRAM-SHA-1', 'SCRAM-SHA-256'],
+    #             'roles': [{'db': 'admin', 'role': 'readWriteAnyDatabase'},
+    #                       {'db': 'local', 'role': 'read'}],
+    #             'user': <user>,
+    #             'userId': <userId>
+    #         }
+    #     ]
+    # }
+    user_info = client[config['database']].command({'usersInfo': config['user']})
+
+    can_read_all = False
+    db_names = []
+
+    users = [u for u in user_info.get('users') if u.get('user')==config['user']]
+    if len(users)!=1:
+        LOGGER.warning('Could not find any users for {}'.format(config['user']))
+        return []
+
+    for role_info in users[0].get('roles', []):
+        if role_info.get('role') in ['read', 'readWrite']:
+            if role_info.get('db'):
+                db_names.append(role_info['db'])
+        elif role_info.get('role') in ['readAnyDatabase', 'readWriteAnyDatabase']:
+            can_read_all = True
+            break
+
+    if can_read_all:
+        db_names =  client.list_database_names()
+
+    return [d for d in db_names if d not in IGNORE_DBS]
+
+
 
 def produce_collection_schema(collection):
     collection_name = collection.name
@@ -64,12 +109,10 @@ def produce_collection_schema(collection):
     }
 
 
-def do_discover(client):
+def do_discover(client, config):
     streams = []
 
-    database_names = client.list_database_names()
-    for db_name in [d for d in database_names
-                    if d not in IGNORE_DBS]:
+    for db_name in get_databases(client, config):
         db = client[db_name]
 
         collection_names = db.list_collection_names()
@@ -230,7 +273,7 @@ def main_impl():
     common.include_schemas_in_destination_stream_name = (config.get('include_schemas_in_destination_stream_name') == 'true')
 
     if args.discover:
-         do_discover(client)
+         do_discover(client, config)
     elif args.catalog:
         state = args.state or {}
         do_sync(client, args.catalog.to_dict(), state)

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -156,7 +156,9 @@ def sync_stream(client, stream, state):
         try:
             stream_projection = json.loads(stream_projection)
         except:
-            raise common.InvalidProjectionException("The projection provided is not valid JSON")
+            err_msg = "The projection: {} for stream {} is not valid json"
+            raise common.InvalidProjectionException(err_msg.format(stream_projection,
+                                                                   tap_stream_id))
     else:
         LOGGER.warning('There is no projection found for stream %s, all fields will be retrieved.', stream['tap_stream_id'])
 

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -59,6 +59,7 @@ def get_databases(client, config):
             if role_info.get('db'):
                 db_names.append(role_info['db'])
         elif role_info.get('role') in ['readAnyDatabase', 'readWriteAnyDatabase']:
+            # If user has either of these roles they can query all databases
             can_read_all = True
             break
 

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -19,7 +19,7 @@ TIMES = {}
 class InvalidProjectionException(Exception):
     """Raised if projection blacklists _id"""
 
-class UnsupportedReplicationKeyType(Exception):
+class UnsupportedReplicationKeyTypeException(Exception):
     """Raised if key type is unsupported"""
     
 def calculate_destination_stream_name(stream):

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -53,10 +53,8 @@ def class_to_string(bookmark_value, bookmark_type):
         return utils.strftime(utc_datetime)
     if bookmark_type == 'Timestamp':
         return '{}.{}'.format(bookmark_value.time, bookmark_value.inc)
-    if bookmark_type in ['int', 'ObjectId', 'Decimal', 'float']:
+    if bookmark_type in ['int', 'ObjectId']:
         return str(bookmark_value)
-    if bookmark_type == 'str':
-        return bookmark_value
     raise UnsupportedReplicationKeyTypeException("{} is not a supported replication key type".format(bookmark_type))
 
 
@@ -67,15 +65,9 @@ def string_to_class(str_value, type_value):
         return int(str_value)
     if type_value == 'ObjectId':
         return objectid.ObjectId(str_value)
-    if type_value == 'Decimal':
-        return decimal.Decimal(str_value)
-    if type_value == 'float':
-        return float(str_value)
     if type_value == 'Timestamp':
         split_value = str_value.split('.')
         return bson.timestamp.Timestamp(int(split_value[0]), int(split_value[1]))
-    if type_value == 'str':
-        return str_val
     raise UnsupportedReplicationKeyTypeException("{} is not a supported replication key type".format(bookmark_type))
 
 def transform_value(value):


### PR DESCRIPTION
- If replication key changes, wipe state and resync collection
- Only support `datetime`, `timestamp`, `int`, and `ObjectId` replication key types
- Only discover databases that the user has read access to