### PR TITLE
Oplog sync performance enhancements

### DIFF
--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -22,6 +22,9 @@ class InvalidProjectionException(Exception):
 class UnsupportedReplicationKeyTypeException(Exception):
     """Raised if key type is unsupported"""
 
+class MongoAssertionException(Exception):
+    """Raised if Mongo exhibits incorrect behavior"""
+
 def calculate_destination_stream_name(stream):
     s_md = metadata.to_map(stream['metadata'])
     if INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME:

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -146,7 +146,11 @@ def sync_collection(client, stream, state, stream_projection):
     ) as cursor:
         for row in cursor:
             if row.get('ns') != '{}.{}'.format(database_name, collection_name):
+                state = update_bookmarks(state,
+                                         tap_stream_id,
+                                         row['ts'])
                 continue
+
             row_op = row['op']
             if row_op == 'i':
 

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -141,8 +141,9 @@ def sync_collection(client, stream, state, stream_projection):
     # regardless of whether its long lived or not.
     with client.local.oplog.rs.find(
             oplog_query,
-            projection,
-            sort=[('$natural', pymongo.ASCENDING)]) as cursor:
+            sort=[('$natural', pymongo.ASCENDING)],
+            oplog_replay=True
+    ) as cursor:
         for row in cursor:
             if row.get('ns') != '{}.{}'.format(database_name, collection_name):
                 continue

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -119,20 +119,14 @@ def sync_collection(client, stream, state, stream_projection):
 
     oplog_query = {
         'ts': {'$gte': oplog_ts}
-        #'op': {'$in': ['i', 'u', 'd']},
-        #'ns': '{}.{}'.format(database_name, collection_name)
     }
 
     projection = transform_projection(stream_projection)
 
-    # _id is the key-property so don't let it get turned off
-    if stream_projection and stream_projection.get('_id') == 0:
-        stream_projection.pop('_id')
-    if stream_projection and not stream_projection:
-        stream_projection = None
+    oplog_replay = True if stream_projection is None else False
 
-    LOGGER.info('Querying %s with:\n\tFind Parameters: %s\n\tProjection: %s',
-                tap_stream_id, oplog_query, projection)
+    LOGGER.info('Querying %s with:\n\tFind Parameters: %s\n\tProjection: %s\n\toplog_replay: %s',
+                tap_stream_id, oplog_query, projection, oplog_replay)
 
     update_buffer = set()
 
@@ -141,14 +135,23 @@ def sync_collection(client, stream, state, stream_projection):
     # regardless of whether its long lived or not.
     with client.local.oplog.rs.find(
             oplog_query,
+            projection,
             sort=[('$natural', pymongo.ASCENDING)],
-            oplog_replay=True
+            oplog_replay=oplog_replay
     ) as cursor:
         for row in cursor:
+            # assertions that mongo is respecing the ts query and sort order
+            if row.get('ts') and row.get('ts') < oplog_ts:
+                raise common.MongoAssertionException("Mongo is not honoring the query param")
+            if row.get('ts') and row.get('ts') < timestamp.Timestamp(stream_state['oplog_ts_time'],
+                                                                     stream_state['oplog_ts_inc']):
+                raise common.MongoAssertionException("Mongo is not honoring the sort ascending param")
+
             if row.get('ns') != '{}.{}'.format(database_name, collection_name):
-                state = update_bookmarks(state,
-                                         tap_stream_id,
-                                         row['ts'])
+                if row.get('ts'):
+                    state = update_bookmarks(state,
+                                             tap_stream_id,
+                                             row['ts'])
                 continue
 
             row_op = row['op']

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -123,7 +123,7 @@ def sync_collection(client, stream, state, stream_projection):
 
     projection = transform_projection(stream_projection)
 
-    oplog_replay = True if stream_projection is None else False
+    oplog_replay = stream_projection is None
 
     LOGGER.info('Querying %s with:\n\tFind Parameters: %s\n\tProjection: %s\n\toplog_replay: %s',
                 tap_stream_id, oplog_query, projection, oplog_replay)
@@ -145,7 +145,8 @@ def sync_collection(client, stream, state, stream_projection):
                 raise common.MongoAssertionException("Mongo is not honoring the query param")
             if row.get('ts') and row.get('ts') < timestamp.Timestamp(stream_state['oplog_ts_time'],
                                                                      stream_state['oplog_ts_inc']):
-                raise common.MongoAssertionException("Mongo is not honoring the sort ascending param")
+                raise common.MongoAssertionException(
+                    "Mongo is not honoring the sort ascending param")
 
             if row.get('ns') != '{}.{}'.format(database_name, collection_name):
                 if row.get('ts'):


### PR DESCRIPTION
We've received feedback that querying the oplog with `ts` (timestamp), `ns` (collection namespace), and `op` (operation) filters leads to a heavy cpu load on the mongo cluster being queried.  To resolve this, we've done the following:
- Removed the `ns` and `op` filters from the mongo query and filtered out the unwanted results in the tap
- Added the `oplog_replay=True` flag to oplog queries IF there is no projection being used.
  - `oplog_replay` is an internal optimization for oplog queries with a filter on `ts`
  - If `oplog_replay=True`, the projection is disregarded.  This MongoDB [Jira Ticket](https://jira.mongodb.org/browse/SERVER-34096) seems to validate this finding

This PR also adds assertions around the range and ordering of the oplog results.  