### PR TITLE
Improved DateTime Handling and Messaging

### DIFF
--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -104,7 +104,9 @@ def safe_transform_datetime(value, path):
                                                                               value.minute,
                                                                               value.second,
                                                                               value.microsecond)
-        raise MongoInvalidDateTimeException("Found invalid datetime at [{}]: {}".format(".".join(path), value))
+        raise MongoInvalidDateTimeException("Found invalid datetime at [{}]: {}".format(
+            ".".join(map(str, path)),
+            value))
     return utils.strftime(utc_datetime)
 
 # pylint: disable=too-many-return-statements


### PR DESCRIPTION
# Description of change
JIRA: https://stitchdata.atlassian.net/browse/SUP-880

The issue being solved here is that `pymongo` will return a `datetime` object with invalid values that then fails our transformation code. Two changes have been made:

- In the event that year is `0`, the value will be manually formatted into an ISO-8601 format without being localized. This is because the lack of support for year `0` is Python specific, and would be better handled downstream.
- In the event that formatting datetimes fails for any other reason, the tap will raise an exception with an informative message that gives the `tap_stream_id`, Object ID, path to the value, and the value itself.

# QA steps
 - [X] automated tests passing
   - Added case to datatyping integration test
   - Awaiting passing of existing automation
 - [X] manual qa steps passing (list below)
   - Manually verified that all path construction code works in isolation
   - Ran through a case that originally threw the exception and verified that it throws a better message as described
   - Ran through the case (for year 0) with the fix implemented, and verified that the value `0000-01-01T00:00:00.000000Z` was written to the output record stream.
 
# Risks

We verified the `list` handling of `path` manually, but did not have a case to run through the code itself.

Other risks include our assumption that this will be handled downstream effectively and that it won't cause issues in the case that the tap is extended to support typed datetime values.

# Rollback steps
 - revert this branch
