### PR TITLE
Added Support for UUID

### DIFF
--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -2,8 +2,8 @@
 import base64
 import datetime
 import time
-import bson
 import uuid
+import bson
 from bson import objectid, timestamp, datetime as bson_datetime
 import singer
 from singer import utils, metadata
@@ -68,6 +68,7 @@ def class_to_string(bookmark_value, bookmark_type):
                                                  .format(bookmark_type))
 
 
+# pylint: disable=too-many-return-statements
 def string_to_class(str_value, type_value):
     if type_value == 'UUID':
         return uuid.UUID(str_value)
@@ -110,7 +111,7 @@ def safe_transform_datetime(value, path):
             value))
     return utils.strftime(utc_datetime)
 
-# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-return-statements,too-many-branches
 def transform_value(value, path):
     if isinstance(value, list):
         # pylint: disable=unnecessary-lambda


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-893

UUID fields would come through the tap as a `uuid.UUID` data type which was not matched in the existing replication key conversion functions, nor the value transformation.

This PR adds cases to each of those portions of the tap, for all sync strategies.

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)
   - N/A all cases covered by automation
 
# Risks
Change is additive, very low chance of extra issues.

# Rollback steps
 - revert this branch
