### PR TITLE
Discover collections in `admin` db and support Int64 replication keys

### DIFF
--- a/bin/test-db
+++ b/bin/test-db
@@ -14,8 +14,8 @@ def start_container(name):
     sudo docker run -e "MONGO_INITDB_ROOT_USERNAME={0}" -e "MONGO_INITDB_ROOT_PASSWORD={1}"\
         -p {2}:{2} --name {3} \
         -d {4}:{5} --replSet rs0
-    """.format(os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_USERNAME'),
-               os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_PASSWORD'),
+    """.format(os.getenv('TAP_MONGODB_USER'),
+               os.getenv('TAP_MONGODB_PASSWORD'),
                27017,
                name,
                image_name,
@@ -35,8 +35,8 @@ def start_container(name):
     CONFIGURE_COMMAND = """
     docker run --rm mongo mongo --host {} \test -u {} -p {} --authenticationDatabase admin --eval {}
     """.format(ip_addr,
-               os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_USERNAME'),
-               os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_PASSWORD',),
+               os.getenv('TAP_MONGODB_USER'),
+               os.getenv('TAP_MONGODB_PASSWORD'),
                '\'rs.initiate({_id: "rs0", members: [{_id: 0, host: "127.0.0.1:27017"}]})\'')
     print(CONFIGURE_COMMAND)
     proc = subprocess.run(CONFIGURE_COMMAND, shell=True)
@@ -69,8 +69,8 @@ def connect_to_db(name):
 
     print("Attempting to connect to running container using a mongo container")
     connect_command_format = CONNECT_COMMAND.format(ip_addr,
-                                                    os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_USERNAME'),
-                                                    os.getenv('STITCH_TAP_MONGODB_TEST_DATABASE_PASSWORD'))
+                                                    os.getenv('TAP_MONGODB_USER'),
+                                                    os.getenv('TAP_MONGODB_PASSWORD'))
     print(connect_command_format)
     # NB: Using call instead of run here because it is blocking
     #     This returns only an exit code.
@@ -83,8 +83,8 @@ DESCRIPTION = """
 Manage docker instance for tap-mssql testing.
 
 Uses environment variables:
-    STITCH_TAP_MONGODB_TEST_DATABASE_USERNAME
-    STITCH_TAP_MONGODB_TEST_DATABASE_PASSWORD
+    TAP_MONGODB_USER
+    TAP_MONGODB_PASSWORD
 """
 parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=RawTextHelpFormatter)
 parser.add_argument('action', choices=['start','stop', 'connect'], help='action to perform with the container')

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -25,7 +25,7 @@ REQUIRED_CONFIG_KEYS = [
     'database'
 ]
 
-IGNORE_DBS = ['admin', 'system', 'local', 'config']
+IGNORE_DBS = ['system', 'local', 'config']
 ROLES_WITHOUT_FIND_PRIVILEGES = {
     'dbAdmin',
     'userAdmin',

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -74,8 +74,10 @@ def string_to_class(str_value, type_value):
         return uuid.UUID(str_value)
     if type_value == 'datetime':
         return singer.utils.strptime_with_tz(str_value)
-    if type_value in ['int', 'Int64']:
+    if type_value == 'int':
         return int(str_value)
+    if type_value == 'Int64':
+        return bson.int64.Int64(str_value)
     if type_value == 'ObjectId':
         return objectid.ObjectId(str_value)
     if type_value == 'Timestamp':

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -62,7 +62,7 @@ def class_to_string(bookmark_value, bookmark_type):
         return '{}.{}'.format(bookmark_value.time, bookmark_value.inc)
     if bookmark_type == 'bytes':
         return base64.b64encode(bookmark_value).decode('utf-8')
-    if bookmark_type in ['int', 'ObjectId', 'str', 'UUID']:
+    if bookmark_type in ['int', 'Int64', 'ObjectId', 'str', 'UUID']:
         return str(bookmark_value)
     raise UnsupportedReplicationKeyTypeException("{} is not a supported replication key type"
                                                  .format(bookmark_type))
@@ -74,7 +74,7 @@ def string_to_class(str_value, type_value):
         return uuid.UUID(str_value)
     if type_value == 'datetime':
         return singer.utils.strptime_with_tz(str_value)
-    if type_value == 'int':
+    if type_value in ['int', 'Int64']:
         return int(str_value)
     if type_value == 'ObjectId':
         return objectid.ObjectId(str_value)


### PR DESCRIPTION
# Description of change
1. Remove `admin` from the discovery blacklist, allowing the tap to discover collections in the `admin` db
2. Add support for replication keys of type Int64.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
  - Cloned connections and verified that this resolved the issue for both (1) and (2)
 
# Risks
None

# Rollback steps
 - revert this branch
