### PR TITLE
add float as a supported replication key

### DIFF
--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -62,7 +62,7 @@ def class_to_string(bookmark_value, bookmark_type):
         return '{}.{}'.format(bookmark_value.time, bookmark_value.inc)
     if bookmark_type == 'bytes':
         return base64.b64encode(bookmark_value).decode('utf-8')
-    if bookmark_type in ['int', 'Int64', 'ObjectId', 'str', 'UUID']:
+    if bookmark_type in ['int', 'Int64', 'float', 'ObjectId', 'str', 'UUID']:
         return str(bookmark_value)
     raise UnsupportedReplicationKeyTypeException("{} is not a supported replication key type"
                                                  .format(bookmark_type))
@@ -78,6 +78,8 @@ def string_to_class(str_value, type_value):
         return int(str_value)
     if type_value == 'Int64':
         return bson.int64.Int64(str_value)
+    if type_value == 'float':
+        return float(str_value)
     if type_value == 'ObjectId':
         return objectid.ObjectId(str_value)
     if type_value == 'Timestamp':


### PR DESCRIPTION
# Description of change
Added `float` as a supported replication key type

# QA steps
 - [x] automated tests passing
  - Added a tap-tester test around this that failed before this change and passed after
 - [ ] manual qa steps passing (list below)
 
# Risks
n/a

# Rollback steps
 - revert this branch
