### PR TITLE
Add verify mode option to config

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -349,19 +349,21 @@ def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
 
-    no_verify_mode = config.get('ssh') == 'true' and config.get('ssl') == 'true'
+    # Default SSL verify mode to true, give option to disable
+    verify_mode = config.get('verify_mode', 'true') == 'true'
+    use_ssl = config.get('ssl') == 'true'
 
     connection_params = {"host": config['host'],
                          "port": int(config['port']),
                          "username": config.get('user', None),
                          "password": config.get('password', None),
                          "authSource": config['database'],
-                         "ssl": (config.get('ssl') == 'true'),
+                         "ssl": use_ssl,
                          "replicaset": config.get('replica_set', None),
                          "readPreference": 'secondaryPreferred'}
 
     # NB: "ssl_cert_reqs" must ONLY be supplied if `SSL` is true.
-    if no_verify_mode:
+    if not verify_mode and use_ssl:
         connection_params["ssl_cert_reqs"] = ssl.CERT_NONE
 
     client = pymongo.MongoClient(**connection_params)


### PR DESCRIPTION
# Description of change
Change verify mode to be an optional config argument, instead of assuming that using an SSH tunnel invalidates the Subject of the SSL cert verification.

`verify_mode` defaults to `"true"` and removing it will disable Certificate Name verification on the connection. This is useful if you have a self-signed cert attached to your mongo instance or for some other network topological reason the name verification doesn't apply.

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)
    - None. Relying on automation to run through the code and confirm that this has no effect on existing configs.
 
# Risks
Low, this is an additive optional property. In most cases it should have no effect.

# Rollback steps
 - revert this branch
