### PR TITLE
Build and Write Schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_mongodb tap_mongodb/sync_strategies -d missing-docstring,fixme,duplicate-code,line-too-long
+	pylint tap_mongodb tap_mongodb/sync_strategies -d missing-docstring,fixme,duplicate-code,line-too-long,too-many-statements,too-many-locals

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -279,6 +279,9 @@ def sync_stream(client, stream, state):
 
     common.COUNTS[tap_stream_id] = 0
     common.TIMES[tap_stream_id] = 0
+    common.SCHEMA_COUNT[tap_stream_id] = 0
+    common.SCHEMA_TIMES[tap_stream_id] = 0
+
 
     md_map = metadata.to_map(stream['metadata'])
     replication_method = metadata.get(md_map, (), 'replication-method')
@@ -292,6 +295,7 @@ def sync_stream(client, stream, state):
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
     write_schema_message(stream)
+    common.SCHEMA_COUNT[tap_stream_id] += 1
 
     with metrics.job_timer('sync_table') as timer:
         timer.tags['database'] = database_name

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -65,7 +65,7 @@ def class_to_string(bookmark_value, bookmark_type):
         return '{}.{}'.format(bookmark_value.time, bookmark_value.inc)
     if bookmark_type == 'bytes':
         return base64.b64encode(bookmark_value).decode('utf-8')
-    if bookmark_type in ['int', 'Int64', 'ObjectId', 'str', 'UUID']:
+    if bookmark_type in ['int', 'Int64', 'float', 'ObjectId', 'str', 'UUID']:
         return str(bookmark_value)
     raise UnsupportedReplicationKeyTypeException("{} is not a supported replication key type"
                                                  .format(bookmark_type))
@@ -81,6 +81,8 @@ def string_to_class(str_value, type_value):
         return int(str_value)
     if type_value == 'Int64':
         return bson.int64.Int64(str_value)
+    if type_value == 'float':
+        return float(str_value)
     if type_value == 'ObjectId':
         return objectid.ObjectId(str_value)
     if type_value == 'Timestamp':

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -3,8 +3,8 @@ import base64
 import datetime
 import time
 import uuid
-import bson
 import decimal
+import bson
 from bson import objectid, timestamp, datetime as bson_datetime
 import singer
 from singer import utils, metadata
@@ -218,7 +218,7 @@ def add_to_any_of(schema, value):
                 field_schema_entry.pop('multipleOf')
                 return True
             if field_schema_entry.get('type') == 'number' and not field_schema_entry.get('multipleOf'):
-                has_float= True
+                has_float = True
 
         if not has_float:
             if has_date:
@@ -273,7 +273,7 @@ def add_to_any_of(schema, value):
 def row_to_schema(schema, row):
     changed = False
 
-    for field,value in row.items():
+    for field, value in row.items():
         if isinstance(value, (bson_datetime.datetime,
                               timestamp.Timestamp,
                               datetime.datetime,
@@ -283,12 +283,12 @@ def row_to_schema(schema, row):
                               list)):
 
             # get pointer to field's anyOf list
-            if not schema.get('properties',{}).get(field):
+            if not schema.get('properties', {}).get(field):
                 schema['properties'][field] = {'anyOf': [{}]}
-            anyOf_schema = schema['properties'][field]['anyOf']
+            anyof_schema = schema['properties'][field]['anyOf']
 
             # add value's schema to anyOf list
-            changed = add_to_any_of(anyOf_schema, value) or changed
+            changed = add_to_any_of(anyof_schema, value) or changed
 
     return changed
 
@@ -431,15 +431,16 @@ def get_sync_summary(catalog):
         schema_duration = SCHEMA_TIMES[stream_id]
         if stream_time == 0:
             stream_time = 0.000001
-        row = [db_name,
-               collection_name,
-               replication_method,
-               '{} records'.format(stream_count),
-               '{:.1f} records/second'.format(stream_count/stream_time),
-               '{:.5f} seconds'.format(stream_time),
-               '{} schemas'.format(schemas_written),
-               '{:.5f} seconds'.format(schema_duration),
-               '{:.2f}%'.format(100*schema_duration/stream_time)
+        row = [
+            db_name,
+            collection_name,
+            replication_method,
+            '{} records'.format(stream_count),
+            '{:.1f} records/second'.format(stream_count/stream_time),
+            '{:.5f} seconds'.format(stream_time),
+            '{} schemas'.format(schemas_written),
+            '{:.5f} seconds'.format(schema_duration),
+            '{:.2f}%'.format(100*schema_duration/stream_time)
         ]
         rows.append(row)
 

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -161,6 +161,82 @@ def transform_value(value, path):
 
     return value
 
+# "anyOf": {}
+# "additionalProperties": true
+
+
+# {"type": "object", "properties": {"foo": "anyOf" ..., additionalProperties: true}}
+
+# {"type": "object", "properties": {}}
+
+def row_to_schema_message(schema, row):
+    changed = False
+    # walk the row (recursively?)
+    for field,value in row.items():
+        if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
+            if schema.get('properties',{}).get(field):
+                anyOf_schema = schema['properties'][field]['anyOf']
+                has_date = False
+                for field_schema_entry in anyOf_schema:
+                    if field_schema_entry.get('format') == 'date-time':
+                        has_date = True
+                        break
+                if not has_date:
+                    anyOf_schema.insert(0, {"type": "string", "format": "date-time"})
+                    changed = True
+            else:
+                schema['properties'][field] = {"anyOf": [{"type": "string",
+                                                          "format": "date-time"},
+                                                         {}]}
+                changed = True
+        elif isinstance(value, bson.decimal128.Decimal128):
+            if schema.get('properties',{}).get(field):
+                anyOf_schema = schema['properties'][field]['anyOf']
+                has_date = False
+                has_decimal = False
+                for field_schema_entry in anyOf_schema:
+                    if field_schema_entry.get('format') == 'date-time':
+                        has_date = True
+                    elif field_schema_entry.get('type') == 'number':
+                        has_decimal = True
+                if not has_decimal:
+                    if has_date:
+                        anyOf_schema.insert(1, {"type": "number", "multipleOf": 1e-34})
+                    else:
+                        anyOf_schema.insert(0, {"type": "number", "multipleOf": 1e-34})
+                    changed = True
+            else:
+                schema['properties'][field] = {"anyOf": [{"type": "number",
+                                                          "multipleOf": 1e-34},
+                                                         {}]}
+                changed = True
+        elif isinstance(value, dict):
+            object_schema = {"type": "object", "properties": {}}
+            if not schema.get('properties',{}).get(field):
+                schema['properties'][field] =  {"anyOf": [object_schema, {}]}
+            else:
+                anyof_schema = schema['properties'][field]['anyOf']
+                anyof_schema.insert(-1, object_schema)
+            if row_to_schema_message(object_schema, value):
+                changed = True
+        elif isinstance(value, list):
+            list_schema = {"type": "array", "items": {}}
+            if not schema.get('properties',{}).get(field):
+                schema['properties'][field] =  {"anyOf": [list_schema, {}]}
+            else:
+                anyof_schema = schema['properties'][field]['anyOf']
+                anyof_schema.insert(-1, object_schema)
+            if row_to_schema_message(list_schema, value):
+                changed = True
+
+    return changed
+
+    # in  the case where you find a  date
+    # check if its in the schema; when it is you do nothing, when its not you add it and flip the bit to true
+
+
+# returns (schemaMessage, true / false)
+
 
 def row_to_singer_record(stream, row, version, time_extracted):
     # pylint: disable=unidiomatic-typecheck

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -166,13 +166,19 @@ def transform_value(value, path):
 
     return value
 
-# "anyOf": {}
-# "additionalProperties": true
+def row_to_singer_record(stream, row, version, time_extracted):
+    # pylint: disable=unidiomatic-typecheck
+    try:
+        row_to_persist = {k:transform_value(v, [k]) for k, v in row.items()
+                          if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
+    except MongoInvalidDateTimeException as ex:
+        raise Exception("Error syncing collection {}, object ID {} - {}".format(stream["tap_stream_id"], row['_id'], ex))
 
-
-# {"type": "object", "properties": {"foo": "anyOf" ..., additionalProperties: true}}
-
-# {"type": "object", "properties": {}}
+    return singer.RecordMessage(
+        stream=calculate_destination_stream_name(stream),
+        record=row_to_persist,
+        version=version,
+        time_extracted=time_extracted)
 
 def add_to_any_of(schema, value):
     changed = False
@@ -269,7 +275,6 @@ def add_to_any_of(schema, value):
             schema.insert(-1, list_schema)
     return changed
 
-
 def row_to_schema(schema, row):
     changed = False
 
@@ -291,121 +296,6 @@ def row_to_schema(schema, row):
             changed = add_to_any_of(anyof_schema, value) or changed
 
     return changed
-
-
-# GenSon to build a base schema. Walk both structures and annotate the special types
-#from genson import SchemaBuilder
-
-# def row_to_schema_message(schema, singer_row, raw_row):
-#     from genson import SchemaBuilder
-#     sb = SchemaBuilder()
-#     sb.add_object(singer_row)
-#     schema = sb.to_schema()
-#     schema.pop("$schema")
-#     schema.pop("required")
-
-#     return _row_to_schema_message(schema, raw_row)
-
-# def _row_to_schema_message(schema, row):
-#     for field,value in row.items():
-#         if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
-#             schema['properties'][field]['format'] = 'date-time'
-#         elif isinstance(value, bson.decimal128.Decimal128):
-#             schema['properties'][field]['multipleOf'] = 1e-34
-#         elif isinstance(value, dict):
-#             _row_to_schema_message(schema['properties'][field], value)
-#         elif isinstance(value, list):
-#             # not ready yet
-#             for v in value:
-#                 # Fix this?
-#                 _row_to_schema_message(schema['properties'][field], v)
-
-#     return schema
-
-# if DeepDiff(old_schema, new_schema, ignore_order=True) == {}: they are the same
-
-# def row_to_schema_message(schema, row):
-#     changed = False
-#     # walk the row (recursively?)
-#     for field,value in row.items():
-#         if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
-#             if schema.get('properties',{}).get(field):
-#                 anyOf_schema = schema['properties'][field]['anyOf']
-#                 has_date = False
-#                 for field_schema_entry in anyOf_schema:
-#                     if field_schema_entry.get('format') == 'date-time':
-#                         has_date = True
-#                         break
-#                 if not has_date:
-#                     anyOf_schema.insert(0, {"type": "string", "format": "date-time"})
-#                     changed = True
-#             else:
-#                 schema['properties'][field] = {"anyOf": [{"type": "string",
-#                                                           "format": "date-time"},
-#                                                          {}]}
-#                 changed = True
-#         elif isinstance(value, bson.decimal128.Decimal128):
-#             if schema.get('properties',{}).get(field):
-#                 anyOf_schema = schema['properties'][field]['anyOf']
-#                 has_date = False
-#                 has_decimal = False
-#                 for field_schema_entry in anyOf_schema:
-#                     if field_schema_entry.get('format') == 'date-time':
-#                         has_date = True
-#                     elif field_schema_entry.get('type') == 'number':
-#                         has_decimal = True
-#                 if not has_decimal:
-#                     if has_date:
-#                         anyOf_schema.insert(1, {"type": "number", "multipleOf": 1e-34})
-#                     else:
-#                         anyOf_schema.insert(0, {"type": "number", "multipleOf": 1e-34})
-#                     changed = True
-#             else:
-#                 schema['properties'][field] = {"anyOf": [{"type": "number",
-#                                                           "multipleOf": 1e-34},
-#                                                          {}]}
-#                 changed = True
-#         elif isinstance(value, dict):
-#             object_schema = {"type": "object", "properties": {}}
-#             if not schema.get('properties',{}).get(field):
-#                 schema['properties'][field] =  {"anyOf": [object_schema, {}]}
-#             else:
-#                 anyof_schema = schema['properties'][field]['anyOf']
-#                 anyof_schema.insert(-1, object_schema)
-#             if row_to_schema_message(object_schema, value):
-#                 changed = True
-#         elif isinstance(value, list):
-#             list_schema = {"type": "array", "items": {}}
-#             if not schema.get('properties',{}).get(field):
-#                 schema['properties'][field] =  {"anyOf": [list_schema, {}]}
-#             else:
-#                 anyof_schema = schema['properties'][field]['anyOf']
-#                 anyof_schema.insert(-1, object_schema)
-#             if row_to_schema_message(list_schema, value):
-#                 changed = True
-
-#     return changed
-
-    # in  the case where you find a  date
-    # check if its in the schema; when it is you do nothing, when its not you add it and flip the bit to true
-
-
-# returns (schemaMessage, true / false)
-
-
-def row_to_singer_record(stream, row, version, time_extracted):
-    # pylint: disable=unidiomatic-typecheck
-    try:
-        row_to_persist = {k:transform_value(v, [k]) for k, v in row.items()
-                          if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
-    except MongoInvalidDateTimeException as ex:
-        raise Exception("Error syncing collection {}, object ID {} - {}".format(stream["tap_stream_id"], row['_id'], ex))
-
-    return singer.RecordMessage(
-        stream=calculate_destination_stream_name(stream),
-        record=row_to_persist,
-        version=version,
-        time_extracted=time_extracted)
 
 def get_sync_summary(catalog):
     headers = [['database',

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -4,6 +4,7 @@ import datetime
 import time
 import uuid
 import bson
+import decimal
 from bson import objectid, timestamp, datetime as bson_datetime
 import singer
 from singer import utils, metadata
@@ -16,6 +17,8 @@ INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME = False
 UPDATE_BOOKMARK_PERIOD = 1000
 COUNTS = {}
 TIMES = {}
+SCHEMA_COUNT = {}
+SCHEMA_TIMES = {}
 
 class InvalidProjectionException(Exception):
     """Raised if projection blacklists _id"""
@@ -189,96 +192,105 @@ def add_to_any_of(schema, value):
                 has_date = True
             elif field_schema_entry.get('type') == 'number':
                 has_decimal = True
-            if not has_decimal:
-                if has_date:
-                    schema.insert(1, {"type": "number", "multipleOf": 1e-34})
-                else:
-                    schema.insert(0, {"type": "number", "multipleOf": 1e-34})
-                changed = True
-    elif isinstance(value, dict):
-        object_schema = {"type": "object", "properties": {}}
-        if row_to_schema_message(object_schema, value):
+        if not has_decimal:
+            if has_date:
+                schema.insert(1, {"type": "number", "multipleOf": decimal.Decimal('1e-34')})
+            else:
+                schema.insert(0, {"type": "number", "multipleOf": decimal.Decimal('1e-34')})
             changed = True
-        schema.insert(-1, object_schema)
-    elif isinstance(value, list):
-        pass
+    elif isinstance(value, dict):
+        has_object = False
 
+        # get pointer to object schema and see if it already existed
+        object_schema = {"type": "object", "properties": {}}
+        for field_schema_entry in schema:
+            if field_schema_entry.get('type') == 'object':
+                object_schema = field_schema_entry
+                has_object = True
+
+        # see if object schema changed
+        if row_to_schema(object_schema, value):
+            changed = True
+
+            # if it changed and existed, it's reference was modified
+            # if it changed and didn't exist, insert it
+            if not has_object:
+                schema.insert(-1, object_schema)
+    elif isinstance(value, list):
+        has_list = False
+
+        # get pointer to list's anyOf schema and see if list schema already existed
+        list_schema = {"type": "array", "items": {"anyOf": [{}]}}
+        for field_schema_entry in schema:
+            if field_schema_entry.get('type') == 'array':
+                list_schema = field_schema_entry
+                has_list = True
+        anyof_schema = list_schema['items']['anyOf']
+
+        # see if list schema changed
+        list_entry_changed = False
+        for list_entry in value:
+            list_entry_changed = add_to_any_of(anyof_schema, list_entry) or list_entry_changed
+            changed = changed or list_entry_changed
+
+        # if it changed and existed, it's reference was modified
+        # if it changed and didn't exist, insert it
+        if not has_list and list_entry_changed:
+            schema.insert(-1, list_schema)
     return changed
 
 
-# def row_to_schema_message(schema, row):
-#     changed = False
-#     # walk the row (recursively?)
-#     for field,value in row.items():
-#         if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
-#             if schema.get('properties',{}).get(field):
-#                 anyOf_schema = schema['properties'][field]['anyOf']
-#                 changed = changed or add_to_any_of(anyOf_schema, value)
-#             else:
-#                 schema['properties'][field] = {"anyOf": [{"type": "string",
-#                                                           "format": "date-time"},
-#                                                          {}]}
-#                 changed = True
+def row_to_schema(schema, row):
+    changed = False
 
-#         elif isinstance(value, bson.decimal128.Decimal128):
-#             if schema.get('properties',{}).get(field):
-#                 anyOf_schema = schema['properties'][field]['anyOf']
-#                 changed = changed or add_to_any_of(anyOf_schema, value)
-#             else:
-#                 schema['properties'][field] = {"anyOf": [{"type": "number",
-#                                                           "multipleOf": 1e-34},
-#                                                          {}]}
-#                 changed = True
+    for field,value in row.items():
+        if isinstance(value, (bson_datetime.datetime,
+                              timestamp.Timestamp,
+                              datetime.datetime,
+                              bson.decimal128.Decimal128,
+                              dict,
+                              list)):
 
-#         elif isinstance(value, dict):
-#             if schema.get('properties',{}).get(field):
-#                 anyof_schema = schema['properties'][field]['anyOf']
-#             else:
-#                 schema['properties'][field] = {'anyOf': [{}]}
-#                 anyof_schema = schema['properties'][field]['anyOf']
-#             dict_schema_changed = add_to_any_of(anyof_schema, value)
-#             changed = changed or dict_schema_changed
+            # get pointer to field's anyOf list
+            if not schema.get('properties',{}).get(field):
+                schema['properties'][field] = {'anyOf': [{}]}
+            anyOf_schema = schema['properties'][field]['anyOf']
 
-#         elif isinstance(value, list):
-#             list_schema = {"type": "array", "items": {"anyOf": [{}]}}
-#             if not schema.get('properties',{}).get(field):
-#                 schema['properties'][field] = {'anyOf': [{}]}
-#             schema['properties'][field]['anyOf'].insert(-1, list_schema)
-#             for list_entry in value:
-#                 list_entry_changed = add_to_any_of(list_schema['items']['anyOf'], list_entry)
-#                 changed = changed or list_entry_changed
-#     return changed
+            # add value's schema to anyOf list
+            changed = add_to_any_of(anyOf_schema, value) or changed
+
+    return changed
 
 
 # GenSon to build a base schema. Walk both structures and annotate the special types
 #from genson import SchemaBuilder
 
-def row_to_schema_message(schema, singer_row, raw_row):
-    from genson import SchemaBuilder
-    sb = SchemaBuilder()
-    sb.add_object(singer_row)
-    schema = sb.to_schema()
-    schema.pop("$schema")
-    schema.pop("required")
+# def row_to_schema_message(schema, singer_row, raw_row):
+#     from genson import SchemaBuilder
+#     sb = SchemaBuilder()
+#     sb.add_object(singer_row)
+#     schema = sb.to_schema()
+#     schema.pop("$schema")
+#     schema.pop("required")
 
-    return _row_to_schema_message(schema, raw_row)
+#     return _row_to_schema_message(schema, raw_row)
 
-def _row_to_schema_message(schema, row):
-    for field,value in row.items():
-        if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
-            schema['properties'][field]['format'] = 'date-time'
-        elif isinstance(value, bson.decimal128.Decimal128):
-            schema['properties'][field]['multipleOf'] = 1e-34
-        elif isinstance(value, dict):
-            _row_to_schema_message(schema['properties'][field], value)
-        elif isinstance(value, list):
-            # not ready yet
-            for v in value:
-                # Fix this?
-                _row_to_schema_message(schema['properties'][field], v)
+# def _row_to_schema_message(schema, row):
+#     for field,value in row.items():
+#         if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
+#             schema['properties'][field]['format'] = 'date-time'
+#         elif isinstance(value, bson.decimal128.Decimal128):
+#             schema['properties'][field]['multipleOf'] = 1e-34
+#         elif isinstance(value, dict):
+#             _row_to_schema_message(schema['properties'][field], value)
+#         elif isinstance(value, list):
+#             # not ready yet
+#             for v in value:
+#                 # Fix this?
+#                 _row_to_schema_message(schema['properties'][field], v)
 
-    return schema
-    
+#     return schema
+
 # if DeepDiff(old_schema, new_schema, ignore_order=True) == {}: they are the same
 
 # def row_to_schema_message(schema, row):
@@ -369,7 +381,11 @@ def get_sync_summary(catalog):
                 'collection',
                 'replication method',
                 'total records',
-                'write speed']]
+                'write speed',
+                'total time',
+                'schemas written',
+                'schema build duration',
+                'percent building schemas']]
 
     rows = []
     for stream_id, stream_count in COUNTS.items():
@@ -380,13 +396,20 @@ def get_sync_summary(catalog):
         replication_method = metadata.get(md_map, (), 'replication-method')
 
         stream_time = TIMES[stream_id]
+        schemas_written = SCHEMA_COUNT[stream_id]
+        schema_duration = SCHEMA_TIMES[stream_id]
         if stream_time == 0:
             stream_time = 0.000001
         row = [db_name,
                collection_name,
                replication_method,
                '{} records'.format(stream_count),
-               '{:.1f} records/second'.format(stream_count/stream_time)]
+               '{:.1f} records/second'.format(stream_count/stream_time),
+               '{:.5f} seconds'.format(stream_time),
+               '{} schemas'.format(schemas_written),
+               '{:.5f} seconds'.format(schema_duration),
+               '{:.2f}%'.format(100*schema_duration/stream_time)
+        ]
         rows.append(row)
 
     data = headers + rows

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -176,6 +176,7 @@ def transform_value(value, path):
 
 def add_to_any_of(schema, value):
     changed = False
+
     if isinstance(value, (bson_datetime.datetime, timestamp.Timestamp, datetime.datetime)):
         has_date = False
         for field_schema_entry in schema:
@@ -277,6 +278,7 @@ def row_to_schema(schema, row):
                               timestamp.Timestamp,
                               datetime.datetime,
                               bson.decimal128.Decimal128,
+                              float,
                               dict,
                               list)):
 

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -105,7 +105,7 @@ def sync_collection(client, stream, state, projection):
         time_extracted = utils.now()
         start_time = time.time()
 
-        schema =  {"type": "object", "properties": {}}
+        schema = {"type": "object", "properties": {}}
         for row in cursor:
             rows_saved += 1
 

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -105,8 +105,18 @@ def sync_collection(client, stream, state, projection):
         time_extracted = utils.now()
         start_time = time.time()
 
+        schema =  {"type": "object", "properties": {}}
         for row in cursor:
             rows_saved += 1
+
+            schema_build_start_time = time.time()
+            if common.row_to_schema(schema, row):
+                singer.write_message(singer.SchemaMessage(
+                    stream=common.calculate_destination_stream_name(stream),
+                    schema=schema,
+                    key_properties=['_id']))
+                common.SCHEMA_COUNT[stream['tap_stream_id']] += 1
+            common.SCHEMA_TIMES[stream['tap_stream_id']] += time.time() - schema_build_start_time
 
             record_message = common.row_to_singer_record(stream,
                                                          row,

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -90,6 +90,9 @@ def sync_collection(client, stream, state, projection):
         time_extracted = utils.now()
         start_time = time.time()
         for row in cursor:
+            # schema, updated = common.row_to_schema_message(schema, row)
+            # if updated
+            #   emit schema
             record_message = common.row_to_singer_record(stream,
                                                          row,
                                                          stream_version,

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -83,17 +83,23 @@ def sync_collection(client, stream, state, projection):
 
 
     # query collection
+    schema =  {"type": "object", "properties": {}}
     with collection.find(find_filter,
                          projection,
                          sort=[(replication_key_name, pymongo.ASCENDING)]) as cursor:
         rows_saved = 0
         time_extracted = utils.now()
         start_time = time.time()
-        #schema =  {"type": "object", "properties": {}}
+
         for row in cursor:
-            # schema, updated = common.row_to_schema_message(schema, row)
-            # if updated
-            #   emit schema
+            schema_build_start_time = time.time()
+            if common.row_to_schema(schema, row):
+                singer.write_message(singer.SchemaMessage(
+                    stream=common.calculate_destination_stream_name(stream),
+                    schema=schema,
+                    key_properties=['_id']))
+                common.SCHEMA_COUNT[tap_stream_id] += 1
+            common.SCHEMA_TIMES[tap_stream_id] += time.time() - schema_build_start_time
 
 
             record_message = common.row_to_singer_record(stream,

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -89,15 +89,22 @@ def sync_collection(client, stream, state, projection):
         rows_saved = 0
         time_extracted = utils.now()
         start_time = time.time()
+        #schema =  {"type": "object", "properties": {}}
         for row in cursor:
             # schema, updated = common.row_to_schema_message(schema, row)
             # if updated
             #   emit schema
+
+
             record_message = common.row_to_singer_record(stream,
                                                          row,
                                                          stream_version,
                                                          time_extracted)
 
+            # gen_schema = common.row_to_schema_message(schema, record_message.record, row)
+            # if DeepDiff(schema, gen_schema, ignore_order=True) != {}:
+            #   emit gen_schema
+            #   schema = gen_schema
             singer.write_message(record_message)
             rows_saved += 1
 

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -83,7 +83,7 @@ def sync_collection(client, stream, state, projection):
 
 
     # query collection
-    schema =  {"type": "object", "properties": {}}
+    schema = {"type": "object", "properties": {}}
     with collection.find(find_filter,
                          projection,
                          sort=[(replication_key_name, pymongo.ASCENDING)]) as cursor:

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -140,7 +140,7 @@ def sync_collection(client, stream, state, stream_projection):
                 tap_stream_id, oplog_query, projection, oplog_replay)
 
     update_buffer = set()
-    schema =  {"type": "object", "properties": {}}
+    schema = {"type": "object", "properties": {}}
     # consider adding oplog_replay, but this would require removing the projection
     # default behavior is a non_tailable cursor but we might want a tailable one
     # regardless of whether its long lived or not.

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -47,6 +47,17 @@ def update_bookmarks(state, tap_stream_id, ts):
 
     return state
 
+def write_schema(schema, row, stream):
+    schema_build_start_time = time.time()
+    if common.row_to_schema(schema, row):
+        singer.write_message(singer.SchemaMessage(
+            stream=common.calculate_destination_stream_name(stream),
+            schema=schema,
+            key_properties=['_id']))
+        common.SCHEMA_COUNT[stream['tap_stream_id']] += 1
+    common.SCHEMA_TIMES[stream['tap_stream_id']] += time.time() - schema_build_start_time
+
+
 def transform_projection(projection):
     base_projection = {
         "ts": 1, "ns": 1, "op": 1, 'o2': 1
@@ -129,7 +140,7 @@ def sync_collection(client, stream, state, stream_projection):
                 tap_stream_id, oplog_query, projection, oplog_replay)
 
     update_buffer = set()
-
+    schema =  {"type": "object", "properties": {}}
     # consider adding oplog_replay, but this would require removing the projection
     # default behavior is a non_tailable cursor but we might want a tailable one
     # regardless of whether its long lived or not.
@@ -156,8 +167,9 @@ def sync_collection(client, stream, state, stream_projection):
                 continue
 
             row_op = row['op']
-            if row_op == 'i':
 
+            if row_op == 'i':
+                write_schema(schema, row['o'], stream)
                 record_message = common.row_to_singer_record(stream,
                                                              row['o'],
                                                              version,
@@ -178,6 +190,7 @@ def sync_collection(client, stream, state, stream_projection):
                 # Delete ops only contain the _id of the row deleted
                 row['o'][SDC_DELETED_AT] = row['ts']
 
+                write_schema(schema, row['o'], stream)
                 record_message = common.row_to_singer_record(stream,
                                                              row['o'],
                                                              version,
@@ -197,6 +210,7 @@ def sync_collection(client, stream, state, stream_projection):
                                                  stream_projection,
                                                  database_name,
                                                  collection_name):
+                    write_schema(schema, buffered_row, stream)
                     record_message = common.row_to_singer_record(stream,
                                                                  buffered_row,
                                                                  version,
@@ -214,6 +228,7 @@ def sync_collection(client, stream, state, stream_projection):
                                                  stream_projection,
                                                  database_name,
                                                  collection_name):
+                    write_schema(schema, buffered_row, stream)
                     record_message = common.row_to_singer_record(stream,
                                                                  buffered_row,
                                                                  version,
@@ -232,6 +247,7 @@ def sync_collection(client, stream, state, stream_projection):
                                          stream_projection,
                                          database_name,
                                          collection_name):
+            write_schema(schema, buffered_row, stream)
             record_message = common.row_to_singer_record(stream,
                                                          buffered_row,
                                                          version,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,218 +1,320 @@
 import unittest
 import bson
 import decimal
+from jsonschema import validate
 
 import tap_mongodb.sync_strategies.common as common
 
 class TestRowToSchemaMessage(unittest.TestCase):
-    def test_one(self):
-        row = {"a_str": "hello"}
-        schema = {"type": "object", "properties": {}}
-        schema = common.row_to_schema_message(schema, row, row)
-
-        self.assertEqual({'properties': {'a_str': {'type': 'string'}}, 'type': 'object'}, schema)
-
-    def test_two(self):
-        row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
-        schema = {"type": "object", "properties": {}}
-
-        singer_row = {k:common.transform_value(v, [k]) for k, v in row.items()
-                          if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
-        changed = common.row_to_schema_message(schema, singer_row, row)
-        self.assertEqual({'properties': {'a_date': {'type': 'string', 'format': 'date-time'}}, 'type': 'object'}, changed)
-
-        import ipdb; ipdb.set_trace()
-        1+1
-        
-    # def test_no_change(self):
+    # def test_one(self):
     #     row = {"a_str": "hello"}
     #     schema = {"type": "object", "properties": {}}
-    #     changed = common.row_to_schema_message(schema, row)
-    #     self.assertFalse(changed)
+    #     schema = common.row_to_schema_message(schema, row, row)
 
-    #     # another row that looks the same keeps changed false
-    #     changed = common.row_to_schema_message(schema, row)
-    #     self.assertFalse(changed)
+    #     self.assertEqual({'properties': {'a_str': {'type': 'string'}}, 'type': 'object'}, schema)
 
-    #     row = {"a_str": "hello",
-    #            "a_date": bson.timestamp.Timestamp(1565897157, 1)}
-    #     changed = common.row_to_schema_message(schema, row)
-    #     # a different looking row makes the schema change
-    #     self.assertTrue(changed)
-
-    #     # the same (different) row again sets changed back to false
-    #     changed = common.row_to_schema_message(schema, row)
-    #     self.assertFalse(changed)
-
-
-    # def test_simple_date(self):
+    # def test_two(self):
     #     row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
     #     schema = {"type": "object", "properties": {}}
-    #     changed = common.row_to_schema_message(schema, row)
 
-    #     expected = {"type": "object",
-    #                 "properties": {
-    #                     "a_date": {
-    #                         "anyOf": [{"type": "string",
-    #                                    "format": "date-time"},
-    #                                   {}]
-    #                     }
-    #                 }
-    #     }
-    #     self.assertTrue(changed)
-    #     self.assertEqual(expected, schema)
+    #     singer_row = {k:common.transform_value(v, [k]) for k, v in row.items()
+    #                       if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
+    #     changed = common.row_to_schema_message(schema, singer_row, row)
+    #     self.assertEqual({'properties': {'a_date': {'type': 'string', 'format': 'date-time'}}, 'type': 'object'}, changed)
+
+    def test_no_change(self):
+        row = {
+            "a_str": "hello",
+            "a_list": ["foo", "bar", 1, 2, {"name": "nick"}],
+            "an_object": {
+                "a_nested_str": "baz",
+                "a_nested_list": [1, 2, "hi"]
+            }
+        }
+
+        schema = {"type": "object", "properties": {}}
+
+        changed = common.row_to_schema(schema, row)
+        self.assertFalse(changed)
+
+        # another row that looks the same keeps changed false
+        changed = common.row_to_schema(schema, row)
+        self.assertFalse(changed)
+
+        # a different looking row makes the schema change
+        row = {"a_str": "hello",
+               "a_date": bson.timestamp.Timestamp(1565897157, 1)}
+        changed = common.row_to_schema(schema, row)
+        self.assertTrue(changed)
+
+        # the same (different) row again sets changed back to false
+        changed = common.row_to_schema(schema, row)
+        self.assertFalse(changed)
 
 
-    # def test_simple_decimal(self):
-    #     row = {"a_decimal": bson.Decimal128(decimal.Decimal('1.34'))}
-    #     schema = {"type": "object", "properties": {}}
-    #     changed = common.row_to_schema_message(schema, row)
+    def test_simple_date(self):
+        row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema(schema, row)
 
-    #     expected = {"type": "object",
-    #                 "properties": {
-    #                     "a_decimal": {
-    #                         "anyOf": [{"type": "number",
-    #                                    "multipleOf": 1e-34},
-    #                                   {}]
-    #                     }
-    #                 }
-    #     }
-    #     self.assertTrue(changed)
-    #     self.assertEqual(expected, schema)
+        expected = {"type": "object",
+                    "properties": {
+                        "a_date": {
+                            "anyOf": [{"type": "string",
+                                       "format": "date-time"},
+                                      {}]
+                        }
+                    }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
 
 
-    # def test_decimal_and_date(self):
-    #     date_row = {"a_field": bson.timestamp.Timestamp(1565897157, 1)}
-    #     decimal_row = {"a_field": bson.Decimal128(decimal.Decimal('1.34'))}
+    def test_simple_decimal(self):
+        row = {"a_decimal": bson.Decimal128(decimal.Decimal('1.34'))}
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema(schema, row)
 
-    #     schema = {"type": "object", "properties": {}}
-                
-    #     changed_date = common.row_to_schema_message(schema, date_row)
-    #     changed_decimal = common.row_to_schema_message(schema, decimal_row)
+        expected = {"type": "object",
+                    "properties": {
+                        "a_decimal": {
+                            "anyOf": [{"type": "number",
+                                       "multipleOf": decimal.Decimal('1e-34')},
+                                      {}]
+                        }
+                    }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
 
-    #     expected = {
-    #         "type": "object",
-    #         "properties": {
-    #             "a_field": {
-    #                 "anyOf": [
-    #                     {"type": "string",
-    #                      "format": "date-time"},
-    #                     {"type": "number",
-    #                      "multipleOf": 1e-34},
-    #                     {}
-    #                 ]
-    #             }
-    #         }
-    #     }
-    #     self.assertTrue(changed_date)
-    #     self.assertTrue(changed_decimal)
-    #     self.assertEqual(expected, schema)
+
+    def test_decimal_and_date(self):
+        date_row = {"a_field": bson.timestamp.Timestamp(1565897157, 1)}
+        decimal_row = {"a_field": bson.Decimal128(decimal.Decimal('1.34'))}
+
+        schema = {"type": "object", "properties": {}}
+
+        changed_date = common.row_to_schema(schema, date_row)
+        changed_decimal = common.row_to_schema(schema, decimal_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "a_field": {
+                    "anyOf": [
+                        {"type": "string",
+                         "format": "date-time"},
+                        {"type": "number",
+                         "multipleOf": decimal.Decimal('1e-34')},
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed_date)
+        self.assertTrue(changed_decimal)
+        self.assertEqual(expected, schema)
+
+
+    def test_nested_data(self):
+        date_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+        schema = {"type": "object", "properties": {}}
+
+        changed = common.row_to_schema(schema, date_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "a_field": {
+                                    "anyOf": [
+                                        {"type": "string",
+                                         "format": "date-time"},
+                                        {}
+                                    ]
+                                }
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
+
+    def test_date_and_nested_data(self):
+        date_row = {"foo": bson.timestamp.Timestamp(1565897157, 1)}
+        nested_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+        schema = {"type": "object", "properties": {}}
+
+        changed_date = common.row_to_schema(schema, date_row)
+        changed_nested = common.row_to_schema(schema, nested_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "a_field": {
+                                    "anyOf": [
+                                        {"type": "string",
+                                         "format": "date-time"},
+                                        {}
+                                    ]
+                                }
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed_date)
+        self.assertTrue(changed_nested)
+        self.assertEqual(expected, schema)
+
+    def test_array_multiple_types(self):
+        row = {
+            "foo": [
+                bson.timestamp.Timestamp(1565897157, 1),
+                bson.Decimal128(decimal.Decimal('1.34'))
+            ]
+        }
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema(schema, row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    {
+                                        "type": "number",
+                                        "multipleOf": decimal.Decimal('1e-34')
+                                    },
+                                    {}
+                                ]
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
+
+    def test_array_nested(self):
+        row = {
+            "foo": [
+                [
+                    bson.timestamp.Timestamp(1565897157, 1),
+                    bson.Decimal128(decimal.Decimal('1.34'))
+                ],
+                {
+                    "bar": bson.timestamp.Timestamp(1565897157, 1),
+                    "bat": bson.Decimal128(decimal.Decimal('1.34'))
+                }
+            ]
+        }
+        row_2 = {
+            "bar": "1",
+            "foo": [
+                ["bob", "roger"],
+                {
+                    "bar": "bob",
+                    "bat": "roger"
+                }
+            ]
+        }
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema(schema, row)
+        changed_2 = common.row_to_schema(schema, row_2)
         
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "multipleOf": decimal.Decimal('1e-34')
+                                                },
+                                                {}
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "bar": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    {}
+                                                ]
+                                            },
+                                            "bat": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "multipleOf": decimal.Decimal('1e-34')
+                                                    },
+                                                    {}
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {}
+                                ]
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        singer_row = {k:common.transform_value(v, [k]) for k, v in row_2.items()
+                      if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
 
-    # def test_nested_data(self):
-    #     date_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
-    #     schema = {"type": "object", "properties": {}}
-                
-    #     changed = common.row_to_schema_message(schema, date_row)
 
-    #     expected = {
-    #         "type": "object",
-    #         "properties": {
-    #             "foo": {
-    #                 "anyOf": [
-    #                     {
-    #                         "type": "object",
-    #                         "properties": {
-    #                             "a_field": {
-    #                                 "anyOf": [
-    #                                     {"type": "string",
-    #                                      "format": "date-time"},
-    #                                     {}
-    #                                 ]
-    #                             }
-    #                         }
-    #                     },
-    #                     {}
-    #                 ]
-    #             }
-    #         }
-    #     }
-    #     self.assertTrue(changed)
-    #     self.assertEqual(expected, schema)
+        decimal.getcontext().prec=100000
+        validate(instance=singer_row, schema=schema)
 
-    # def test_date_and_nested_data(self):
-    #     date_row = {"foo": bson.timestamp.Timestamp(1565897157, 1)}
-    #     nested_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
-    #     schema = {"type": "object", "properties": {}}
-                
-    #     changed_date = common.row_to_schema_message(schema, date_row)
-    #     changed_nested = common.row_to_schema_message(schema, nested_row)
-
-    #     expected = {
-    #         "type": "object",
-    #         "properties": {
-    #             "foo": {
-    #                 "anyOf": [
-    #                     {
-    #                         "type": "string",
-    #                         "format": "date-time"
-    #                     },
-    #                     {
-    #                         "type": "object",
-    #                         "properties": {
-    #                             "a_field": {
-    #                                 "anyOf": [
-    #                                     {"type": "string",
-    #                                      "format": "date-time"},
-    #                                     {}
-    #                                 ]
-    #                             }
-    #                         }
-    #                     },
-    #                     {}
-    #                 ]
-    #             }
-    #         }
-    #     }
-    #     self.assertTrue(changed_date)
-    #     self.assertTrue(changed_nested)
-    #     self.assertEqual(expected, schema)
-
-    # def test_array_multiple_types(self):
-    #     row = {
-    #         "foo": [
-    #             bson.timestamp.Timestamp(1565897157, 1),
-    #             bson.Decimal128(decimal.Decimal('1.34'))
-    #         ]
-    #     }
-    #     schema = {"type": "object", "properties": {}}
-    #     changed = common.row_to_schema_message(schema, row)
-
-    #     expected = {
-    #         "type": "object",
-    #         "properties": {
-    #             "foo": {
-    #                 "anyOf": [
-    #                     {
-    #                         "type": "array",
-    #                         "items": {
-    #                             "anyOf": [
-    #                                 {
-    #                                     "type": "string",
-    #                                     "format": "date-time"
-    #                                 },
-    #                                 {
-    #                                     "type": "number",
-    #                                     "multipleOf": 1e-34
-    #                                 },
-    #                                 {}
-    #                             ]
-    #                         }
-    #                     },
-    #                     {}
-    #                 ]
-    #             }
-    #         }
-    #     }
-    #     self.assertTrue(changed)
-    #     self.assertEqual(expected, schema)
+        self.assertTrue(changed)
+        self.assertFalse(changed_2)
+        self.assertEqual(expected, schema)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,200 @@
+import unittest
+import bson
+import decimal
+
+import tap_mongodb.sync_strategies.common as common
+
+class TestRowToSchemaMessage(unittest.TestCase):
+    def test_no_change(self):
+        row = {"a_str": "hello"}
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema_message(schema, row)
+        self.assertFalse(changed)
+
+        # another row that looks the same keeps changed false
+        changed = common.row_to_schema_message(schema, row)
+        self.assertFalse(changed)
+
+        row = {"a_str": "hello",
+               "a_date": bson.timestamp.Timestamp(1565897157, 1)}
+        changed = common.row_to_schema_message(schema, row)
+        # a different looking row makes the schema change
+        self.assertTrue(changed)
+
+        # the same (different) row again sets changed back to false
+        changed = common.row_to_schema_message(schema, row)
+        self.assertFalse(changed)
+
+
+    def test_simple_date(self):
+        row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema_message(schema, row)
+
+        expected = {"type": "object",
+                    "properties": {
+                        "a_date": {
+                            "anyOf": [{"type": "string",
+                                       "format": "date-time"},
+                                      {}]
+                        }
+                    }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
+
+
+    def test_simple_decimal(self):
+        row = {"a_decimal": bson.Decimal128(decimal.Decimal('1.34'))}
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema_message(schema, row)
+
+        expected = {"type": "object",
+                    "properties": {
+                        "a_decimal": {
+                            "anyOf": [{"type": "number",
+                                       "multipleOf": 1e-34},
+                                      {}]
+                        }
+                    }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
+
+
+    def test_decimal_and_date(self):
+        date_row = {"a_field": bson.timestamp.Timestamp(1565897157, 1)}
+        decimal_row = {"a_field": bson.Decimal128(decimal.Decimal('1.34'))}
+
+        schema = {"type": "object", "properties": {}}
+                
+        changed_date = common.row_to_schema_message(schema, date_row)
+        changed_decimal = common.row_to_schema_message(schema, decimal_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "a_field": {
+                    "anyOf": [
+                        {"type": "string",
+                         "format": "date-time"},
+                        {"type": "number",
+                         "multipleOf": 1e-34},
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed_date)
+        self.assertTrue(changed_decimal)
+        self.assertEqual(expected, schema)
+        
+
+    def test_nested_data(self):
+        date_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+        schema = {"type": "object", "properties": {}}
+                
+        changed = common.row_to_schema_message(schema, date_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "a_field": {
+                                    "anyOf": [
+                                        {"type": "string",
+                                         "format": "date-time"},
+                                        {}
+                                    ]
+                                }
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)
+
+    def test_date_and_nested_data(self):
+        date_row = {"foo": bson.timestamp.Timestamp(1565897157, 1)}
+        nested_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+        schema = {"type": "object", "properties": {}}
+                
+        changed_date = common.row_to_schema_message(schema, date_row)
+        changed_nested = common.row_to_schema_message(schema, nested_row)
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "a_field": {
+                                    "anyOf": [
+                                        {"type": "string",
+                                         "format": "date-time"},
+                                        {}
+                                    ]
+                                }
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed_date)
+        self.assertTrue(changed_nested)
+        import ipdb; ipdb.set_trace()
+        1+1
+        self.assertEqual(expected, schema)
+
+    # def test_array_multiple_types(self):
+    #     row = {
+    #         "foo": [
+    #             bson.timestamp.Timestamp(1565897157, 1),
+    #             bson.Decimal128(decimal.Decimal('1.34'))
+    #         ]
+    #     }
+    #     schema = {"type": "object", "properties": {}}
+    #     changed = common.row_to_schema_message(schema, row)
+
+    #     expected = {
+    #         "type": "object",
+    #         "properties": {
+    #             "anyOf": [
+    #                 {
+    #                     "type": "array",
+    #                     "items": {
+    #                         "anyOf": [
+    #                             {
+    #                                 "type": "string",
+    #                                 "format": "date-time"
+    #                             },
+    #                             {
+    #                                 "type": "number",
+    #                                 "multipleOf": 1e-34
+    #                             },
+    #                             {}
+    #                         ]
+    #                     }
+    #                 },
+    #                 {}
+    #             ]
+    #         }
+    #     }
+
+    #     self.assertTrue(changed)
+    #     self.assertEqual(expected, schema)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,195 +5,214 @@ import decimal
 import tap_mongodb.sync_strategies.common as common
 
 class TestRowToSchemaMessage(unittest.TestCase):
-    def test_no_change(self):
+    def test_one(self):
         row = {"a_str": "hello"}
         schema = {"type": "object", "properties": {}}
-        changed = common.row_to_schema_message(schema, row)
-        self.assertFalse(changed)
+        schema = common.row_to_schema_message(schema, row, row)
 
-        # another row that looks the same keeps changed false
-        changed = common.row_to_schema_message(schema, row)
-        self.assertFalse(changed)
+        self.assertEqual({'properties': {'a_str': {'type': 'string'}}, 'type': 'object'}, schema)
 
-        row = {"a_str": "hello",
-               "a_date": bson.timestamp.Timestamp(1565897157, 1)}
-        changed = common.row_to_schema_message(schema, row)
-        # a different looking row makes the schema change
-        self.assertTrue(changed)
-
-        # the same (different) row again sets changed back to false
-        changed = common.row_to_schema_message(schema, row)
-        self.assertFalse(changed)
-
-
-    def test_simple_date(self):
+    def test_two(self):
         row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
         schema = {"type": "object", "properties": {}}
-        changed = common.row_to_schema_message(schema, row)
 
-        expected = {"type": "object",
-                    "properties": {
-                        "a_date": {
-                            "anyOf": [{"type": "string",
-                                       "format": "date-time"},
-                                      {}]
-                        }
-                    }
-        }
-        self.assertTrue(changed)
-        self.assertEqual(expected, schema)
+        singer_row = {k:common.transform_value(v, [k]) for k, v in row.items()
+                          if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
+        changed = common.row_to_schema_message(schema, singer_row, row)
+        self.assertEqual({'properties': {'a_date': {'type': 'string', 'format': 'date-time'}}, 'type': 'object'}, changed)
 
+        import ipdb; ipdb.set_trace()
+        1+1
+        
+    # def test_no_change(self):
+    #     row = {"a_str": "hello"}
+    #     schema = {"type": "object", "properties": {}}
+    #     changed = common.row_to_schema_message(schema, row)
+    #     self.assertFalse(changed)
 
-    def test_simple_decimal(self):
-        row = {"a_decimal": bson.Decimal128(decimal.Decimal('1.34'))}
-        schema = {"type": "object", "properties": {}}
-        changed = common.row_to_schema_message(schema, row)
+    #     # another row that looks the same keeps changed false
+    #     changed = common.row_to_schema_message(schema, row)
+    #     self.assertFalse(changed)
 
-        expected = {"type": "object",
-                    "properties": {
-                        "a_decimal": {
-                            "anyOf": [{"type": "number",
-                                       "multipleOf": 1e-34},
-                                      {}]
-                        }
-                    }
-        }
-        self.assertTrue(changed)
-        self.assertEqual(expected, schema)
+    #     row = {"a_str": "hello",
+    #            "a_date": bson.timestamp.Timestamp(1565897157, 1)}
+    #     changed = common.row_to_schema_message(schema, row)
+    #     # a different looking row makes the schema change
+    #     self.assertTrue(changed)
+
+    #     # the same (different) row again sets changed back to false
+    #     changed = common.row_to_schema_message(schema, row)
+    #     self.assertFalse(changed)
 
 
-    def test_decimal_and_date(self):
-        date_row = {"a_field": bson.timestamp.Timestamp(1565897157, 1)}
-        decimal_row = {"a_field": bson.Decimal128(decimal.Decimal('1.34'))}
+    # def test_simple_date(self):
+    #     row = {"a_date": bson.timestamp.Timestamp(1565897157, 1)}
+    #     schema = {"type": "object", "properties": {}}
+    #     changed = common.row_to_schema_message(schema, row)
 
-        schema = {"type": "object", "properties": {}}
+    #     expected = {"type": "object",
+    #                 "properties": {
+    #                     "a_date": {
+    #                         "anyOf": [{"type": "string",
+    #                                    "format": "date-time"},
+    #                                   {}]
+    #                     }
+    #                 }
+    #     }
+    #     self.assertTrue(changed)
+    #     self.assertEqual(expected, schema)
+
+
+    # def test_simple_decimal(self):
+    #     row = {"a_decimal": bson.Decimal128(decimal.Decimal('1.34'))}
+    #     schema = {"type": "object", "properties": {}}
+    #     changed = common.row_to_schema_message(schema, row)
+
+    #     expected = {"type": "object",
+    #                 "properties": {
+    #                     "a_decimal": {
+    #                         "anyOf": [{"type": "number",
+    #                                    "multipleOf": 1e-34},
+    #                                   {}]
+    #                     }
+    #                 }
+    #     }
+    #     self.assertTrue(changed)
+    #     self.assertEqual(expected, schema)
+
+
+    # def test_decimal_and_date(self):
+    #     date_row = {"a_field": bson.timestamp.Timestamp(1565897157, 1)}
+    #     decimal_row = {"a_field": bson.Decimal128(decimal.Decimal('1.34'))}
+
+    #     schema = {"type": "object", "properties": {}}
                 
-        changed_date = common.row_to_schema_message(schema, date_row)
-        changed_decimal = common.row_to_schema_message(schema, decimal_row)
+    #     changed_date = common.row_to_schema_message(schema, date_row)
+    #     changed_decimal = common.row_to_schema_message(schema, decimal_row)
 
-        expected = {
-            "type": "object",
-            "properties": {
-                "a_field": {
-                    "anyOf": [
-                        {"type": "string",
-                         "format": "date-time"},
-                        {"type": "number",
-                         "multipleOf": 1e-34},
-                        {}
-                    ]
-                }
-            }
-        }
-        self.assertTrue(changed_date)
-        self.assertTrue(changed_decimal)
-        self.assertEqual(expected, schema)
+    #     expected = {
+    #         "type": "object",
+    #         "properties": {
+    #             "a_field": {
+    #                 "anyOf": [
+    #                     {"type": "string",
+    #                      "format": "date-time"},
+    #                     {"type": "number",
+    #                      "multipleOf": 1e-34},
+    #                     {}
+    #                 ]
+    #             }
+    #         }
+    #     }
+    #     self.assertTrue(changed_date)
+    #     self.assertTrue(changed_decimal)
+    #     self.assertEqual(expected, schema)
         
 
-    def test_nested_data(self):
-        date_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
-        schema = {"type": "object", "properties": {}}
+    # def test_nested_data(self):
+    #     date_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+    #     schema = {"type": "object", "properties": {}}
                 
-        changed = common.row_to_schema_message(schema, date_row)
+    #     changed = common.row_to_schema_message(schema, date_row)
 
-        expected = {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "anyOf": [
-                        {
-                            "type": "object",
-                            "properties": {
-                                "a_field": {
-                                    "anyOf": [
-                                        {"type": "string",
-                                         "format": "date-time"},
-                                        {}
-                                    ]
-                                }
-                            }
-                        },
-                        {}
-                    ]
-                }
-            }
-        }
-        self.assertTrue(changed)
-        self.assertEqual(expected, schema)
+    #     expected = {
+    #         "type": "object",
+    #         "properties": {
+    #             "foo": {
+    #                 "anyOf": [
+    #                     {
+    #                         "type": "object",
+    #                         "properties": {
+    #                             "a_field": {
+    #                                 "anyOf": [
+    #                                     {"type": "string",
+    #                                      "format": "date-time"},
+    #                                     {}
+    #                                 ]
+    #                             }
+    #                         }
+    #                     },
+    #                     {}
+    #                 ]
+    #             }
+    #         }
+    #     }
+    #     self.assertTrue(changed)
+    #     self.assertEqual(expected, schema)
 
-    def test_date_and_nested_data(self):
-        date_row = {"foo": bson.timestamp.Timestamp(1565897157, 1)}
-        nested_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
-        schema = {"type": "object", "properties": {}}
+    # def test_date_and_nested_data(self):
+    #     date_row = {"foo": bson.timestamp.Timestamp(1565897157, 1)}
+    #     nested_row = {"foo": {"a_field": bson.timestamp.Timestamp(1565897157, 1)}}
+    #     schema = {"type": "object", "properties": {}}
                 
-        changed_date = common.row_to_schema_message(schema, date_row)
-        changed_nested = common.row_to_schema_message(schema, nested_row)
+    #     changed_date = common.row_to_schema_message(schema, date_row)
+    #     changed_nested = common.row_to_schema_message(schema, nested_row)
 
-        expected = {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        {
-                            "type": "object",
-                            "properties": {
-                                "a_field": {
-                                    "anyOf": [
-                                        {"type": "string",
-                                         "format": "date-time"},
-                                        {}
-                                    ]
-                                }
-                            }
-                        },
-                        {}
-                    ]
-                }
-            }
-        }
-        self.assertTrue(changed_date)
-        self.assertTrue(changed_nested)
-        self.assertEqual(expected, schema)
+    #     expected = {
+    #         "type": "object",
+    #         "properties": {
+    #             "foo": {
+    #                 "anyOf": [
+    #                     {
+    #                         "type": "string",
+    #                         "format": "date-time"
+    #                     },
+    #                     {
+    #                         "type": "object",
+    #                         "properties": {
+    #                             "a_field": {
+    #                                 "anyOf": [
+    #                                     {"type": "string",
+    #                                      "format": "date-time"},
+    #                                     {}
+    #                                 ]
+    #                             }
+    #                         }
+    #                     },
+    #                     {}
+    #                 ]
+    #             }
+    #         }
+    #     }
+    #     self.assertTrue(changed_date)
+    #     self.assertTrue(changed_nested)
+    #     self.assertEqual(expected, schema)
 
-    def test_array_multiple_types(self):
-        row = {
-            "foo": [
-                bson.timestamp.Timestamp(1565897157, 1),
-                bson.Decimal128(decimal.Decimal('1.34'))
-            ]
-        }
-        schema = {"type": "object", "properties": {}}
-        changed = common.row_to_schema_message(schema, row)
+    # def test_array_multiple_types(self):
+    #     row = {
+    #         "foo": [
+    #             bson.timestamp.Timestamp(1565897157, 1),
+    #             bson.Decimal128(decimal.Decimal('1.34'))
+    #         ]
+    #     }
+    #     schema = {"type": "object", "properties": {}}
+    #     changed = common.row_to_schema_message(schema, row)
 
-        expected = {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "anyOf": [
-                        {
-                            "type": "array",
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    {
-                                        "type": "number",
-                                        "multipleOf": 1e-34
-                                    },
-                                    {}
-                                ]
-                            }
-                        },
-                        {}
-                    ]
-                }
-            }
-        }
-        self.assertTrue(changed)
-        self.assertEqual(expected, schema)
+    #     expected = {
+    #         "type": "object",
+    #         "properties": {
+    #             "foo": {
+    #                 "anyOf": [
+    #                     {
+    #                         "type": "array",
+    #                         "items": {
+    #                             "anyOf": [
+    #                                 {
+    #                                     "type": "string",
+    #                                     "format": "date-time"
+    #                                 },
+    #                                 {
+    #                                     "type": "number",
+    #                                     "multipleOf": 1e-34
+    #                                 },
+    #                                 {}
+    #                             ]
+    #                         }
+    #                     },
+    #                     {}
+    #                 ]
+    #             }
+    #         }
+    #     }
+    #     self.assertTrue(changed)
+    #     self.assertEqual(expected, schema)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -157,8 +157,6 @@ class TestRowToSchemaMessage(unittest.TestCase):
         }
         self.assertTrue(changed_date)
         self.assertTrue(changed_nested)
-        import ipdb; ipdb.set_trace()
-        1+1
         self.assertEqual(expected, schema)
 
     # def test_array_multiple_types(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -159,40 +159,41 @@ class TestRowToSchemaMessage(unittest.TestCase):
         self.assertTrue(changed_nested)
         self.assertEqual(expected, schema)
 
-    # def test_array_multiple_types(self):
-    #     row = {
-    #         "foo": [
-    #             bson.timestamp.Timestamp(1565897157, 1),
-    #             bson.Decimal128(decimal.Decimal('1.34'))
-    #         ]
-    #     }
-    #     schema = {"type": "object", "properties": {}}
-    #     changed = common.row_to_schema_message(schema, row)
+    def test_array_multiple_types(self):
+        row = {
+            "foo": [
+                bson.timestamp.Timestamp(1565897157, 1),
+                bson.Decimal128(decimal.Decimal('1.34'))
+            ]
+        }
+        schema = {"type": "object", "properties": {}}
+        changed = common.row_to_schema_message(schema, row)
 
-    #     expected = {
-    #         "type": "object",
-    #         "properties": {
-    #             "anyOf": [
-    #                 {
-    #                     "type": "array",
-    #                     "items": {
-    #                         "anyOf": [
-    #                             {
-    #                                 "type": "string",
-    #                                 "format": "date-time"
-    #                             },
-    #                             {
-    #                                 "type": "number",
-    #                                 "multipleOf": 1e-34
-    #                             },
-    #                             {}
-    #                         ]
-    #                     }
-    #                 },
-    #                 {}
-    #             ]
-    #         }
-    #     }
-
-    #     self.assertTrue(changed)
-    #     self.assertEqual(expected, schema)
+        expected = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    {
+                                        "type": "number",
+                                        "multipleOf": 1e-34
+                                    },
+                                    {}
+                                ]
+                            }
+                        },
+                        {}
+                    ]
+                }
+            }
+        }
+        self.assertTrue(changed)
+        self.assertEqual(expected, schema)


### PR DESCRIPTION
# Description of change
- For each record that comes through, recursively walk it and "build" a running schema by:
  - Write `"type": "string", "format": "date-time"` for date-time fields
  - Write `"type": "number", "multipleOf": 1e-34` for decimal fields (mongo bson decimal128 has 34 units of precision: [docs](https://docs.mongodb.com/manual/core/shell-types/#numberdecimal))
  - Write `"type": "number"` for float fields
- If the schema changes as a result of the current record, write a schema message with the updated schema
- Track the amount of time spent building schemas and include it in summary at the end of each run

# QA steps
 - [x] automated tests passing
  - Added unit tests for `row_to_schema` function
  - tap-tester tests still pass
 - [x] manual qa steps passing (list below)
  - tested on connections that were experiencing date-times being loaded as strings and column splitting for doubles, and both issues were fixed
# Risks

# Rollback steps
 - revert this branch
