### PR TITLE
specify from in exceptions, get pylint to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
       - image: mongo:4.2.0-bionic
         environment:
           MONGO_INITDB_ROOT_USERNAME: dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            ls /usr/local/share/virtualenvs/
             run-test --tap=tap-mongodb \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
 
-            echo "Kyle this is the ls for '/usr/local/share/virtualenvs/'
+            echo "Kyle this is the ls for '/usr/local/share/virtualenvs/'"
             ls /usr/local/share/virtualenvs/
 
             echo "Kyle this is the value for STITCH_TAP_NAME"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,13 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            virtualenv -p python3 /usr/local/share/virtualenvs/tap-mongodb
-            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            python3 -mvenv /usr/local/share/virtualenvs/tap-shopify
+            source /usr/local/share/virtualenvs/tap-shopify/bin/activate
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
+            # virtualenv -p python3 /usr/local/share/virtualenvs/tap-mongodb
+            # source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            # pip install .[dev]
       - run:
           name: 'pylint'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
+
             # virtualenv -p python3 /usr/local/share/virtualenvs/tap-mongodb
             # source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
             # pip install .[dev]
@@ -51,7 +52,13 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+
+            echo "Kyle this is the ls for '/usr/local/share/virtualenvs/'
             ls /usr/local/share/virtualenvs/
+
+            echo "Kyle this is the value for STITCH_TAP_NAME"
+            echo $STITCH_TAP_NAME
+
             run-test --tap=tap-mongodb \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           name: 'Setup virtual env'
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-mongodb
-            source /usr/local/share/virtualenvs/tap-shopify/bin/activate
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
             # virtualenv -p python3 /usr/local/share/virtualenvs/tap-mongodb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-shopify
+            python3 -mvenv /usr/local/share/virtualenvs/tap-mongodb
             source /usr/local/share/virtualenvs/tap-shopify/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,14 +58,16 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 19 * * *"
           filters:
             branches:
               only:
                 - master
     jobs:
-      - build
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
-
-            # virtualenv -p python3 /usr/local/share/virtualenvs/tap-mongodb
-            # source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
-            # pip install .[dev]
       - run:
           name: 'pylint'
           command: |
@@ -52,13 +48,6 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox tap-tester.env
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-
-            echo "Kyle this is the ls for '/usr/local/share/virtualenvs/'"
-            ls /usr/local/share/virtualenvs/
-
-            echo "Kyle this is the value for STITCH_TAP_NAME"
-            echo $STITCH_TAP_NAME
-
             run-test --tap=tap-mongodb \
                      --target=target-stitch \
                      --orchestrator=stitch-orchestrator \

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -237,10 +237,10 @@ def load_stream_projection(stream):
 
     try:
         stream_projection = json.loads(stream_projection)
-    except:
+    except Exception as ex:
         err_msg = "The projection: {} for stream {} is not valid json"
         raise common.InvalidProjectionException(err_msg.format(stream_projection,
-                                                               stream['tap_stream_id']))
+                                                               stream['tap_stream_id'])) from ex
 
     if stream_projection and stream_projection.get('_id') == 0:
         raise common.InvalidProjectionException(

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -115,7 +115,7 @@ def safe_transform_datetime(value, path):
                                                                               value.microsecond)
         raise MongoInvalidDateTimeException("Found invalid datetime at [{}]: {}".format(
             ".".join(map(str, path)),
-            value))
+            value)) from ex
     return utils.strftime(utc_datetime)
 
 # pylint: disable=too-many-return-statements,too-many-branches
@@ -172,7 +172,7 @@ def row_to_singer_record(stream, row, version, time_extracted):
         row_to_persist = {k:transform_value(v, [k]) for k, v in row.items()
                           if type(v) not in [bson.min_key.MinKey, bson.max_key.MaxKey]}
     except MongoInvalidDateTimeException as ex:
-        raise Exception("Error syncing collection {}, object ID {} - {}".format(stream["tap_stream_id"], row['_id'], ex))
+        raise Exception("Error syncing collection {}, object ID {} - {}".format(stream["tap_stream_id"], row['_id'], ex)) from ex
 
     return singer.RecordMessage(
         stream=calculate_destination_stream_name(stream),

--- a/tests/test_mongodb_full_table_id.py
+++ b/tests/test_mongodb_full_table_id.py
@@ -99,7 +99,7 @@ class MongoDBFullTableID(unittest.TestCase):
         return "tap_tester_mongodb_full_table_id"
 
     def tap_name(self):
-        return "tap_tester_mongodb_full_table_id"
+        return "tap-mongodb"
 
     def get_type(self):
         return "platform.mongodb"

--- a/tests/test_mongodb_full_table_interruptible.py
+++ b/tests/test_mongodb_full_table_interruptible.py
@@ -91,7 +91,7 @@ class MongoDBFullTableInterruptible(unittest.TestCase):
         return "tap_tester_mongodb_full_table_interruptible"
 
     def tap_name(self):
-        return "tap_tester_mongodb_full_table_interruptible"
+        return "tap-mongodb"
 
     def get_type(self):
         return "platform.mongodb"

--- a/tests/test_mongodb_oplog_aged_out.py
+++ b/tests/test_mongodb_oplog_aged_out.py
@@ -88,7 +88,7 @@ class MongoDBOplogAgedOut(unittest.TestCase):
         return "tap_tester_mongodb_oplog_aged_out"
 
     def tap_name(self):
-        return "tap_tester_mongodb_oplog_aged_out"
+        return "tap-mongodb"
 
     def get_type(self):
         return "platform.mongodb"


### PR DESCRIPTION
# Description of change
Get pylint passing by addressing `raise-missing-from` error.
** Update **
Use v4 tap-tester image, add circleci context-user.
Change tap_name in some tests to get virtual env built correctly.

Added 
# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - Minimal, explicitly specifying exception using from. If implemented incorrectly could cause an unintended exception to be raised.
# Rollback steps
 - revert this branch
