### PR TITLE
If a user has multiple roles that are able to find databases then the…

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -113,6 +113,7 @@ def get_databases(client, config):
         db_names = [d for d in client.list_database_names() if d not in IGNORE_DBS]
     else:
         db_names = [r['db'] for r in roles if r['db'] not in IGNORE_DBS]
+    db_names = list(set(db_names))  # Make sure each db is only in the list once
     LOGGER.info('Datbases: %s', db_names)
     return db_names
 
@@ -384,6 +385,7 @@ def main_impl():
     elif args.catalog:
         state = args.state or {}
         do_sync(client, args.catalog.to_dict(), state)
+
 
 def main():
     try:


### PR DESCRIPTION
… database was returned in the list multiple times.

This patch removes duplicates instances of the data base from the list of discovered databases.

# Description of change
remove duplicates from list of db names.
```
db_names = list(set(db_names))

# QA steps
 - [ ] automated tests passing
 - [ X] manual qa steps passing (list below)
       Ran locally to verify that the catalog only contained a single entry for the stream.
 
# Risks

# Rollback steps
 - revert this branch
