### PR TITLE
Fix duplicated rows

### DIFF
--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -129,7 +129,7 @@ def sync_collection(client, stream, state, stream_projection):
     start_time = time.time()
 
     oplog_query = {
-        'ts': {'$gte': oplog_ts}
+        'ts': {'$gt': oplog_ts}
     }
 
     projection = transform_projection(stream_projection)


### PR DESCRIPTION
# Description of change
Query oplog with 'gt' instead of 'gte'.
Querying with 'gte' will lead to duplicated rows if the last
oplog entry is for a collection that is supposed to be replicated.
Because of the change done in efd5e0fd769b749f247266a88f617a0e617d380a
this will not happen for every sync as it's quite likely that the last
oplog entry references a modification in a different collection.


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
