### PR TITLE
fix for #48

### DIFF
--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -110,7 +110,7 @@ def sync_collection(client, stream, state, projection):
             rows_saved += 1
 
             schema_build_start_time = time.time()
-            if common.row_to_schema(schema, row):
+            if 'schema' not in stream and common.row_to_schema(schema, row):
                 singer.write_message(singer.SchemaMessage(
                     stream=common.calculate_destination_stream_name(stream),
                     schema=schema,


### PR DESCRIPTION
# Description of change
the problem is that the mongo extractor is outputting a SCHEMA for every record, which may be a partial object. when this is consumed by the postgres loader, it fails because the schema keeps getting overwritten and it can't find the `key_properties`. i generate a catalog json with my own python script vs relying on this tap to generate it on the fly. i can't say for sure that this is the right solution (perhaps we should write the key_properties every time), but it is the root cause

Command

`mongo meltano elt --job_id mongo --catalog transformed.json tap-mongodb target-postgres`

Catalog

```json
{
  "streams": [
    {
      "metadata": [
        {
          "breadcrumb": {},
          "metadata": {
            "database-name": "db",
            "replication-method": "FULL_TABLE",
            "selected": true,
            "tap-mongodb.projection": "{\"_id\": 1, \"name\": 1}"
          }
        }
      ],
      "schema": {
        "key_properties": [
          "_id"
        ],
        "properties": {
          "_id": {
            "type": "string"
          },
          "name": {
            "type": "string"
          }
        }
      }
    }
  ]
}
```