### PR TITLE
Update mongo shell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.8.0
             run-test --tap=tap-mongodb tests
-      - run:
-          name: 'Get Curl'
-          command: |
-            apt update
-            apt install -y curl
       - slack/status:
           channel: 'tier-1-taps-monitor'
           mentions: "${CIRCLE_USERNAME}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
             source tap-tester.env
-            wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add -
-            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+            wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
             apt-get update
-            apt-get install -y mongodb-org-shell=4.2.0
+            apt-get install -y mongodb-org-shell
             mongo -u  $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
       - run:
           name: 'Setup virtual env'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add -
             echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
             apt-get update
-            apt-get install -y libcurl3 mongodb-org-shell=4.2.0
+            apt-get install -y mongodb-org-shell=4.2.0
             mongo -u  $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
       - run:
           name: 'Setup virtual env'


### PR DESCRIPTION
# Description of change
This PR removes the workaround added in #73.

The goal of #73 was to fix a seemingly random loss of `curl` being installed in the Docker container. 

I noticed that `libcurl3` was being installed as part of the "Setup Mongo" step. Some googling led me to learn that `libcurl3` cannot be installed with `libcurl4`, which is used by `curl`. So it appears that installing `libcurl3` also caused `curl` to be uninstalled since it's missing a dependency.

I followed Mongo's instructions to just install a newer version of the mongo shell. [Docs here](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
I'm not sure why we pinned the mongo version. But if we are using it to just run a few queries to set up the database, it seems safe to bump the version.

Note that we bumping from version `4.2` to `5.0`. I'm unaware of any breaking changes here.

# Rollback steps
 - revert this branch
