### PR TITLE
Update how PyMongo handles UUIDs

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -371,7 +371,7 @@ def main_impl():
     if not verify_mode and use_ssl:
         connection_params["ssl_cert_reqs"] = ssl.CERT_NONE
 
-    client = pymongo.MongoClient(**connection_params)
+    client = pymongo.MongoClient(uuidRepresentation="standard", **connection_params)
 
     LOGGER.info('Connected to MongoDB host: %s, version: %s',
                 config['host'],


### PR DESCRIPTION
# Description of change
This PR sets the PyMongo client to use the `"standard"` representation of UUID instead of the default `"undefined"` representation.

[From the docs](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient):
> uuidRepresentation: The BSON representation to use when encoding from and decoding to instances of [UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID). Valid values are the strings: “standard”, “pythonLegacy”, “javaLegacy”, “csharpLegacy”, and “unspecified” (the default). New applications should consider setting this to “standard” for cross language compatibility.

I found [this section of the PyMongo docs](https://pymongo.readthedocs.io/en/stable/examples/uuid.html#legacy-handling-of-uuid-data) that gives good background behind the issue here.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
I don't think anyone is leaning on the current representation of UUID. It seems to be broken in terms of our syncing.

# Rollback steps
 - revert this branch
