### PR TITLE
Fix/bookmarking issue on fencepost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+  * Fix bug in oplog bookmarking where the bookmark would not advance due to fencepost querying finding a single record [#80](https://github.com/singer-io/tap-mongodb/pull/80)
+
 ## 2.1.0
   * Optimize oplog extractions to only query for the selected tables [#78](https://github.com/singer-io/tap-mongodb/pull/78)
 

--- a/bin/test-db
+++ b/bin/test-db
@@ -34,7 +34,7 @@ def start_container(name):
 
     ip_addr = get_ip_addr(name)
     CONFIGURE_COMMAND = """
-    docker run --rm mongo mongo --host {} \test -u {} -p {} --authenticationDatabase admin --eval {}
+    docker run --rm mongo mongo --host {} test -u {} -p {} --authenticationDatabase admin --eval {}
     """.format(ip_addr,
                os.getenv('TAP_MONGODB_USER'),
                os.getenv('TAP_MONGODB_PASSWORD'),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='2.1.0',
+      version='2.1.1',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -155,4 +155,4 @@ def sync_collection(client, stream, state, projection):
 
     singer.write_message(activate_version_message)
 
-    LOGGER.info('Syncd {} records for {}'.format(rows_saved, tap_stream_id))
+    LOGGER.info('Synced {} records for {}'.format(rows_saved, tap_stream_id))

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -125,4 +125,4 @@ def sync_collection(client, stream, state, projection):
 
     singer.write_message(activate_version_message)
 
-    LOGGER.info('Syncd %s records for %s', rows_saved, tap_stream_id)
+    LOGGER.info('Synced %s records for %s', rows_saved, tap_stream_id)

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -263,4 +263,4 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
 
     common.COUNTS[tap_stream_id] += rows_saved
     common.TIMES[tap_stream_id] += time.time()-start_time
-    LOGGER.info('Syncd %s records for %s', rows_saved, tap_stream_id)
+    LOGGER.info('Synced %s records for %s', rows_saved, tap_stream_id)

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -250,12 +250,16 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
             rows_saved += 1
 
 
-    if rows_saved == 0:
-        # We went a whole sync where this stream did not see updates. So we can move the bookmark to the max position in the oplog
-        state = update_bookmarks(state,
-                                 tap_stream_id,
-                                 max_oplog_ts)
-        singer.write_message(singer.StateMessage(value=state))
+    # Compare the current bookmark with the max_oplog_ts and write the max
+    bookmarked_ts = timestamp.Timestamp(state.get('bookmarks', {}).get(tap_stream_id, {}).get('oplog_ts_time'),
+                                        state.get('bookmarks', {}).get(tap_stream_id, {}).get('oplog_ts_inc'))
+
+    actual_max_ts = max(bookmarked_ts, max_oplog_ts)
+
+    state = update_bookmarks(state,
+                             tap_stream_id,
+                             actual_max_ts)
+    singer.write_message(singer.StateMessage(value=state))
 
     common.COUNTS[tap_stream_id] += rows_saved
     common.TIMES[tap_stream_id] += time.time()-start_time

--- a/tests/test_mongodb_incremental.py
+++ b/tests/test_mongodb_incremental.py
@@ -230,7 +230,7 @@ class MongoDBIncremental(TestCase):
                                                                    self.expected_sync_streams(),
                                                                    self.expected_pks())
 
-        # verify that the entire collection was syncd by comparing row counts against the source
+        # verify that the entire collection was synced by comparing row counts against the source
         for tap_stream_id in self.expected_sync_streams():
             with self.subTest(stream=tap_stream_id):
 

--- a/tests/test_mongodb_oplog.py
+++ b/tests/test_mongodb_oplog.py
@@ -160,7 +160,7 @@ class MongoDBOplog(unittest.TestCase):
                                                                    self.expected_sync_streams(),
                                                                    self.expected_pks())
 
-        # Verify that the full table was syncd
+        # Verify that the full table was synced
         for tap_stream_id in self.expected_sync_streams():
             self.assertGreaterEqual(record_count_by_stream[tap_stream_id],self.expected_row_counts()[tap_stream_id])
 


### PR DESCRIPTION
# Description of change
Fix an issue where the bookmark for an oplog stream will not advance if there is very little activity for the collection. With this PR we are setting the oplog bookmark to the max of the oplog_ts as of the start of the extraction for the stream or the greatest ts found on a record.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
