### PR TITLE
TDL-19353: pymongo driver issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,14 @@ jobs:
           name: "Unit Tests"
           command: |
             source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
-            pip install pymongo==3.8.0
+            pip install pymongo==3.12.3
             nosetests tests/unittests/
       - run:
           name: 'Integration Tests'
           command: |
             source tap-tester.env
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install pymongo==3.8.0
+            pip install pymongo==3.12.3
             run-test --tap=tap-mongodb tests
       - run:
           name: 'Get Curl'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.2
+  * Update pymongo to v3.12.3 [#81](https://github.com/singer-io/tap-mongodb/pull/81)
+
 ## 2.1.1
   * Fix bug in oplog bookmarking where the bookmark would not advance due to fencepost querying finding a single record [#80](https://github.com/singer-io/tap-mongodb/pull/80)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-mongodb',
       py_modules=['tap_mongodb'],
       install_requires=[
           'singer-python==5.8.0',
-          'pymongo==3.8.0',
+          'pymongo==4.1.1',
           'tzlocal==2.0.0',
           'terminaltables==3.1.0',
       ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-mongodb',
       py_modules=['tap_mongodb'],
       install_requires=[
           'singer-python==5.8.0',
-          'pymongo==4.1.1',
+          'pymongo==3.12.3',
           'tzlocal==2.0.0',
           'terminaltables==3.1.0',
       ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='2.1.1',
+      version='2.1.2',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
TDL-19353: pymongo driver issue
- Upgraded pymongo to the version `3.12.3`

  - 3.8 -> PyMongo supports MongoDB 2.6, 3.0, 3.2, 3.4, 3.6 and 4.0.
  - 3.12.3 -> PyMongo supports MongoDB 2.6, 3.0, 3.2, 3.4, 3.6, 4.0, 4.2, 4.4, and 5.0.
  - 4.1.1 -> PyMongo supports MongoDB 3.6, 4.0, 4.2, 4.4, and 5.0.

- As per this [document](https://www.mongodb.com/docs/atlas/reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances) the minimum pymongo version requirement for serverless instance is `3.12.0`

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
