### PR TITLE
sum string projection as integer of bool

### DIFF
--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -71,6 +71,8 @@ def transform_projection(projection):
         return new_projection
 
     temp_projection = {k:v for k, v in projection.items() if k != '_id'}
+    # int(bool(v)) will return 1 if v is any of non empty string, True or number > 0
+    # To avoid errors when v is a string or boolean, it is converted to int
     is_whitelist = sum([int(bool(v)) for k, v in temp_projection.items()]) > 0
 
     # If only '_id' is included in projection

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -71,7 +71,7 @@ def transform_projection(projection):
         return new_projection
 
     temp_projection = {k:v for k, v in projection.items() if k != '_id'}
-    is_whitelist = sum([v for k, v in temp_projection.items()]) > 0
+    is_whitelist = sum([int(bool(v)) for k, v in temp_projection.items()]) > 0
 
     # If only '_id' is included in projection
     if not temp_projection:


### PR DESCRIPTION
# Description of change

Fixes issue - #93
The change allows user to specify string projection, instead of just integer values 

A sample projection that didn't work before and should be working after merging this PR
`{"name": "$personName"}`

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
