### PR TITLE
Use a projection if we have one

### DIFF
--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -8,8 +8,12 @@ import tap_mongodb.sync_strategies.common as common
 
 LOGGER = singer.get_logger()
 
-def get_max_id_value(collection):
-    row = collection.find_one(sort=[("_id", pymongo.DESCENDING)])
+def get_max_id_value(collection, projection=None):
+    if projection is None:
+        row = collection.find_one(sort=[("_id", pymongo.DESCENDING)])
+    else:
+        row = collection.find_one(sort=[("_id", pymongo.DESCENDING)],
+                                  projection=projection)
     if row:
         return row['_id']
 
@@ -64,7 +68,7 @@ def sync_collection(client, stream, state, projection):
         max_id_type = singer.get_bookmark(state, stream['tap_stream_id'], 'max_id_type')
         max_id_value = common.string_to_class(max_id_value, max_id_type)
     else:
-        max_id_value = get_max_id_value(collection)
+        max_id_value = get_max_id_value(collection, projection)
 
     last_id_fetched = singer.get_bookmark(state,
                                           stream['tap_stream_id'],


### PR DESCRIPTION
# Description of change
This PR adds the use of a projection to the query that fetches the max `_id` from a collection. This allows the document we fetch to contain bad BSON data, but if we don't care to replicate the bad data, the tap won't try to decode those bytes and blow up

This approach was picked over the use of initializing the `MongoClient` with `unicode_decode_error_handler='ignore'` because I think it's valuable to know when non-UTF-8 encoded data has been inserted into Mongo for data we want to sync.

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
    - Ran the tap before and after the change to confirm it works

# Risks
- Low, this unblocks people and doesn't loosen the checks on the data

# Rollback steps
 - revert this branch
