### PR TITLE
Qa/TDL-18949 add versions to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,15 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            run-test --tap=tap-mongodb tests
+            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
+            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            if [ -s ./tests-to-run ]; then
+              for test_file in $(cat ./tests-to-run)
+              do
+                << parameters.test_command >>
+                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+              done
+            fi
       - run:
           name: 'Get Curl'
           command: |
@@ -141,7 +149,15 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            run-test --tap=tap-mongodb tests
+            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
+            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            if [ -s ./tests-to-run ]; then
+              for test_file in $(cat ./tests-to-run)
+              do
+                << parameters.test_command >>
+                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+              done
+            fi
       - run:
           name: 'Get Curl'
           command: |
@@ -202,7 +218,15 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            run-test --tap=tap-mongodb tests
+            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
+            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            if [ -s ./tests-to-run ]; then
+              for test_file in $(cat ./tests-to-run)
+              do
+                << parameters.test_command >>
+                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+              done
+            fi
       - run:
           name: 'Get Curl'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,14 +147,19 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            echo "Tests running in this batch: $selected_tests"
-            circleci tests split $selected_tests > ./tests-to-run
+            # selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            # echo "Tests running in this batch:\n $selected_tests"
+            # circleci tests split $selected_tests > ./tests-to-run
+            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
                 run-test --tap=tap-mongodb $test_file
               done
+            else
+              echo "ERROR - File not found or file is empty!" 1>&2
+              exit 5
             fi
       - run:
           name: 'Get Curl'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,6 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                << parameters.test_command >>
                 run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
               done
             fi
@@ -154,7 +153,6 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                << parameters.test_command >>
                 run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
               done
             fi
@@ -223,7 +221,6 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                << parameters.test_command >>
                 run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
               done
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
@@ -148,8 +148,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
@@ -216,8 +216,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
             selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            echo -e "Tests running in this batch:\n $selected_tests"
+            echo -e "Tests running in this batch:\n$selected_tests\n"
             echo $selected_tests > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
@@ -223,7 +223,7 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
             selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            echo -e "Tests running in this batch:\n $selected_tests"
+            echo -e "Tests running in this batch:\n$selected_tests\n"
             echo $selected_tests > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
@@ -248,16 +248,16 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      # - build:
-      #     context:
-      #       - circleci-user
-      #       - tier-1-tap-user
+      - build:
+          context:
+            - circleci-user
+            - tier-1-tap-user
       - build_mongo_4_4:
           context:
             - circleci-user
             - tier-1-tap-user
-          # requires:
-          #   - build
+          requires:
+            - build
       - build_mongo_5_0:
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,8 +259,8 @@ workflows:
           context:
             - circleci-user
             - tier-1-tap-user
-          requires:
-            # - build
+          # requires:
+          #   - build
       - build_mongo_5_0:
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
         command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
 
 jobs:
-  build_mongo_4_2:
+  build:
     executor: tap_tester_mongo_4_2
     steps:
       - checkout
@@ -231,7 +231,7 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - build_mongo_4_2:
+      - build:
           context:
             - circleci-user
             - tier-1-tap-user
@@ -240,13 +240,13 @@ workflows:
             - circleci-user
             - tier-1-tap-user
           requires:
-            - build_mongo_4_2
+            - build
       - build_mongo_5_0:
           context:
             - circleci-user
             - tier-1-tap-user
           requires:
-            - build_mongo_4_2
+            - build
             - build_mongo_4_4
   build_daily:
     <<: *commit_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,16 +148,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
             selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            echo "Tests running in this batch:\n $selected_tests"
-            # circleci tests split $selected_tests > ./tests-to-run
+            echo -e "Tests running in this batch:\n $selected_tests"
             echo $selected_tests > ./tests-to-run
-            # echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            # circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
-              echo $(cat ./tests-to-run)
               for test_file in $(cat ./tests-to-run)
               do
-                echo $test_file
                 run-test --tap=tap-mongodb $test_file
               done
             else
@@ -227,8 +222,9 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            echo -e "Tests running in this batch:\n $selected_tests"
+            echo $selected_tests > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+                run-test --tap=tap-mongodb $test_file
               done
             fi
       - run:
@@ -221,7 +221,7 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+                run-test --tap=tap-mongodb $test_file
               done
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
             pip install pymongo==3.12.3
             echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
             circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
-            if [ -s ./tests-to-run1 ]; then
+            if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
                 run-test --tap=tap-mongodb $test_file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,10 @@ jobs:
             echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
             circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
+              echo $(cat ./tests-to-run)
               for test_file in $(cat ./tests-to-run)
               do
+                echo $test_file
                 run-test --tap=tap-mongodb $test_file
               done
             else
@@ -249,16 +251,16 @@ workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - build:
-          context:
-            - circleci-user
-            - tier-1-tap-user
+      # - build:
+      #     context:
+      #       - circleci-user
+      #       - tier-1-tap-user
       - build_mongo_4_4:
           context:
             - circleci-user
             - tier-1-tap-user
           requires:
-            - build
+            # - build
       - build_mongo_5_0:
           context:
             - circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,8 @@ jobs:
             pip install pymongo==3.12.3
             selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
             echo "Tests running in this batch:\n $selected_tests"
-            circleci tests split $selected_tests > ./tests-to-run
+            # circleci tests split $selected_tests > ./tests-to-run
+            echo $selected_tests > ./tests-to-run
             # echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
             # circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,8 +147,9 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            echo "Tests running in this batch: $selected_tests"
+            circleci tests split $selected_tests > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
@@ -220,11 +221,14 @@ jobs:
             pip install pymongo==3.12.3
             echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
             circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
-            if [ -s ./tests-to-run ]; then
+            if [ -s ./tests-to-run1 ]; then
               for test_file in $(cat ./tests-to-run)
               do
                 run-test --tap=tap-mongodb $test_file
               done
+            else
+              echo "ERROR - File not found or file is empty!" 1>&2
+              exit 5
             fi
       - run:
           name: 'Get Curl'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,8 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
             echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
-            if [ -s ./tests-to-run ]; then
-              for test_file in $(cat ./tests-to-run)
-              do
-                run-test --tap=tap-mongodb $test_file
-              done
-            fi
+            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*"
+            run-test --tap=tap-mongodb tests
       - run:
           name: 'Get Curl'
           command: |
@@ -153,7 +148,7 @@ jobs:
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
-                run-test --tap=bin/${CIRCLE_PROJECT_REPONAME} $test_file
+                run-test --tap=tap-mongodb $test_file
               done
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,11 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            # selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            # echo "Tests running in this batch:\n $selected_tests"
-            # circleci tests split $selected_tests > ./tests-to-run
-            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
+            selected_tests=$(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            echo "Tests running in this batch:\n $selected_tests"
+            circleci tests split $selected_tests > ./tests-to-run
+            # echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
+            # circleci tests glob "tests/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               echo $(cat ./tests-to-run)
               for test_file in $(cat ./tests-to-run)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,6 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "tests/*{data,view}*")
-            circleci tests glob "tests/*{data,view}*" | circleci tests split
             run-test --tap=tap-mongodb tests
       - run:
           name: 'Get Curl'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "tests/*{data,interrupt,open,restrict,view}*")
-            circleci tests glob "tests/*{data,interrupt,open,restrict,view}*"
+            echo $(circleci tests glob "tests/*{data,view}*")
+            circleci tests glob "tests/*{data,view}*" | circleci tests split
             run-test --tap=tap-mongodb tests
       - run:
           name: 'Get Curl'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
-            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
@@ -148,8 +148,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
-            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do
@@ -216,8 +216,8 @@ jobs:
             export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             pip install pymongo==3.12.3
-            echo $(circleci tests glob "test/{data,interrupt,open,restrict,view}")
-            circleci tests glob "test/{data,interrupt,open,restrict,view}" | circleci tests split > ./tests-to-run
+            echo $(circleci tests glob "test/*{data,interrupt,open,restrict,view}*")
+            circleci tests glob "test/*{data,interrupt,open,restrict,view}*" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
               for test_file in $(cat ./tests-to-run)
               do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
       - run:
           name: 'Install Dockerize'
           command: |
-            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -52,10 +52,14 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
             source tap-tester.env
             wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add -
-            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+            echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | \
+                 tee /etc/apt/sources.list.d/mongodb-org-4.2.list
             apt-get update
             apt-get install -y libcurl3 mongodb-org-shell=4.2.0
-            mongo -u  $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
+            mongo -u  $TAP_MONGODB_USER \
+                  -p $TAP_MONGODB_PASSWORD \
+                  --authenticationDatabase admin \
+                  --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
       - run:
           name: 'Setup virtual env'
           command: |
@@ -100,9 +104,9 @@ jobs:
       - run:
           name: 'Install Dockerize'
           command: |
-            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -116,10 +120,14 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
             source tap-tester.env
             wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | \
+                 tee /etc/apt/sources.list.d/mongodb-org-5.0.list
             apt-get update
             apt-get install -y mongodb-org-shell mongodb-mongosh mongodb-org
-            mongosh -u $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
+            mongosh -u $TAP_MONGODB_USER \
+                    -p $TAP_MONGODB_PASSWORD \
+                    --authenticationDatabase admin \
+                    --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
       - run:
           name: 'Setup virtual env'
           command: |
@@ -156,7 +164,7 @@ jobs:
                 run-test --tap=tap-mongodb $test_file
               done
             else
-              echo "ERROR - File not found or file is empty!" 1>&2
+              echo "ERROR - File not found or file is empty!" >&2
               exit 5
             fi
       - run:
@@ -175,9 +183,9 @@ jobs:
       - run:
           name: 'Install Dockerize'
           command: |
-            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+            rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -191,10 +199,14 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
             source tap-tester.env
             wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | \
+                 tee /etc/apt/sources.list.d/mongodb-org-5.0.list
             apt-get update
             apt-get install -y mongodb-org-shell mongodb-mongosh mongodb-org
-            mongosh -u $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
+            mongosh -u $TAP_MONGODB_USER \
+                    -p $TAP_MONGODB_PASSWORD \
+                    --authenticationDatabase admin \
+                    --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
       - run:
           name: 'Setup virtual env'
           command: |
@@ -231,7 +243,7 @@ jobs:
                 run-test --tap=tap-mongodb $test_file
               done
             else
-              echo "ERROR - File not found or file is empty!" 1>&2
+              echo "ERROR - File not found or file is empty!" >&2
               exit 5
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,35 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
 
-jobs:
-  build:
+executors:
+  tap_tester_mongo_4_2:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
-      - image: mongo:4.2.0-bionic
+      - image: singerio/mongo:4.2-bionic
         environment:
           MONGO_INITDB_ROOT_USERNAME: dev
           MONGO_INITDB_ROOT_PASSWORD: Password1
-        command: [mongod, --replSet, rs0]
+        command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
+  tap_tester_mongo_4_4:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: singerio/mongo:4.4-bionic
+        environment:
+          MONGO_INITDB_ROOT_USERNAME: dev
+          MONGO_INITDB_ROOT_PASSWORD: Password1
+        command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
+  tap_tester_mongo_5_0:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: singerio/mongo:5.0
+        environment:
+          MONGO_INITDB_ROOT_USERNAME: dev
+          MONGO_INITDB_ROOT_PASSWORD: Password1
+        command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
+
+jobs:
+  build_mongo_4_2:
+    executor: tap_tester_mongo_4_2
     steps:
       - checkout
       - run:
@@ -70,15 +90,150 @@ jobs:
           only_for_branches: master
       - store_artifacts:
           path: /tmp/tap-mongodb
+  build_mongo_4_4:
+    executor: tap_tester_mongo_4_4
+    steps:
+      - checkout
+      - run:
+          name: 'Install Dockerize'
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: 'Wait for Mongo'
+          command: |
+            dockerize -wait tcp://127.0.0.1:27017 -timeout 1m
+            sleep 10
+      - run:
+          name: 'Setup Mongo'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
+            source tap-tester.env
+            wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+            apt-get update
+            apt-get install -y mongodb-org-shell mongodb-mongosh mongodb-org
+            mongosh -u $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            pyenv local 3.5.6
+            python3 -mvenv /usr/local/share/virtualenvs/tap-mongodb
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install .[dev]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            make test
+      - run:
+          name: "Unit Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            pip install pymongo==3.12.3
+            nosetests tests/unittests/
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source tap-tester.env
+            mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            pip install pymongo==3.12.3
+            run-test --tap=tap-mongodb tests
+      - run:
+          name: 'Get Curl'
+          command: |
+            apt update
+            apt install -y curl
+      - slack/notify-on-failure:
+          only_for_branches: master
+      - store_artifacts:
+          path: /tmp/tap-mongodb
+  build_mongo_5_0:
+    executor: tap_tester_mongo_5_0
+    steps:
+      - checkout
+      - run:
+          name: 'Install Dockerize'
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: 'Wait for Mongo'
+          command: |
+            dockerize -wait tcp://127.0.0.1:27017 -timeout 1m
+            sleep 10
+      - run:
+          name: 'Setup Mongo'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox tap-tester.env
+            source tap-tester.env
+            wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
+            apt-get update
+            apt-get install -y mongodb-org-shell mongodb-mongosh mongodb-org
+            mongosh -u $TAP_MONGODB_USER -p $TAP_MONGODB_PASSWORD --authenticationDatabase admin --eval "rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"$TAP_MONGODB_HOST:$TAP_MONGODB_PORT\"}]})"
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            pyenv local 3.5.6
+            python3 -mvenv /usr/local/share/virtualenvs/tap-mongodb
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install .[dev]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            make test
+      - run:
+          name: "Unit Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-mongodb/bin/activate
+            pip install pymongo==3.12.3
+            nosetests tests/unittests/
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source tap-tester.env
+            mkdir /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            pip install pymongo==3.12.3
+            run-test --tap=tap-mongodb tests
+      - run:
+          name: 'Get Curl'
+          command: |
+            apt update
+            apt install -y curl
+      - slack/notify-on-failure:
+          only_for_branches: master
+      - store_artifacts:
+          path: /tmp/tap-mongodb
 
 workflows:
   version: 2
   commit: &commit_jobs
     jobs:
-      - build:
+      - build_mongo_4_2:
           context:
             - circleci-user
             - tier-1-tap-user
+      - build_mongo_4_4:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - build_mongo_4_2
+      - build_mongo_5_0:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - build_mongo_4_2
+            - build_mongo_4_4
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ jobs:
       - checkout
       - run:
           name: 'Install Dockerize'
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          command: |
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -96,7 +99,10 @@ jobs:
       - checkout
       - run:
           name: 'Install Dockerize'
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          command: |
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -164,7 +170,10 @@ jobs:
       - checkout
       - run:
           name: 'Install Dockerize'
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          command: |
+            wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+            && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.3.0
       - run:
@@ -246,7 +255,6 @@ workflows:
             - circleci-user
             - tier-1-tap-user
           requires:
-            - build
             - build_mongo_4_4
   build_daily:
     <<: *commit_jobs


### PR DESCRIPTION
# Description of change
TDL-18949 previously only version 4.2 was covered under build daily regression.  Update CI/CD to include 4.4 and 5.0.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
