### PR TITLE
update tap-tester to the 18.04 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   tap_tester_mongo_4_2:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-18.04
       - image: singerio/mongo:4.2-bionic
         environment:
           MONGO_INITDB_ROOT_USERNAME: dev
@@ -13,7 +13,7 @@ executors:
         command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
   tap_tester_mongo_4_4:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-18.04
       - image: singerio/mongo:4.4-bionic
         environment:
           MONGO_INITDB_ROOT_USERNAME: dev
@@ -21,7 +21,7 @@ executors:
         command: [mongod, --replSet, rs0, --keyFile, /opt/mongo/keyfile]
   tap_tester_mongo_5_0:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-18.04
       - image: singerio/mongo:5.0
         environment:
           MONGO_INITDB_ROOT_USERNAME: dev


### PR DESCRIPTION
# Description of change
Changes the circleci images to `stitch-tap-tester-18.04` now that `stitch-tap-tester` now uses ubuntu 22.04.
This tap is pinned to python 3.5.6, which is incompatible with 22.04.

# QA steps
 - [x] automated tests passing
 
# Risks
- Low, `stitch-tap-tester-18.04` is the same image as it was previously using.

# Rollback steps
 - revert this branch
