### PR TITLE
add directConnection connection param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.1
+  * Fix issue with SSH tunnel connections by connecting directly to a MongoDB node instead of allowing PyMongo to automatically discover replica sets [#105](https://github.com/singer-io/tap-mongodb/pull/105)
+
 ## 3.0.0
   * Upgrade PyMongo to v4.3+ [#99](https://github.com/singer-io/tap-mongodb/pull/99)
   * Fix uuid transformation [#100](https://github.com/singer-io/tap-mongodb/pull/100)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='3.0.0',
+      version='3.0.1',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -370,7 +370,8 @@ def main_impl():
                          "ssl": use_ssl,
                          "replicaset": config.get('replica_set', None),
                          "readPreference": 'secondaryPreferred',
-                         "datetime_conversion": DatetimeConversion.DATETIME_AUTO}
+                         "datetime_conversion": DatetimeConversion.DATETIME_AUTO,
+                         "directConnection": True}
 
     # NB: "ssl_cert_reqs" must ONLY be supplied if `SSL` is true.
     if not verify_mode and use_ssl:


### PR DESCRIPTION
# Description of change
PyMongo 4 automatically discovers replica sets. When going through an SSH tunnel, these replica sets are not accessible.
Setting `directConnection=True` allows PyMongo to connect directly to a single MongoDB node.
https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#directconnection-defaults-to-false

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
   - Connection through an SSH tunnel no longer gets `ServerSelectionTimeoutError`
 
# Risks
Low. This will match the functionality of PyMongo 3, where the default behavior was to connect to a single server.

# Rollback steps
 - revert this branch
