### PR TITLE
TDL-24216 Rename URI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.2
+  * Fix an issue with connection params when SSL is used [#107](https://github.com/singer-io/tap-mongodb/pull/107)
+
 ## 3.0.1
   * Fix issue with SSH tunnel connections by connecting directly to a MongoDB node instead of allowing PyMongo to automatically discover replica sets [#105](https://github.com/singer-io/tap-mongodb/pull/105)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='3.0.1',
+      version='3.0.2',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -375,7 +375,7 @@ def main_impl():
 
     # NB: "ssl_cert_reqs" must ONLY be supplied if `SSL` is true.
     if not verify_mode and use_ssl:
-        connection_params["ssl_cert_reqs"] = ssl.CERT_NONE
+        connection_params["tlsAllowInvalidCertificates"] = True
 
     client = pymongo.MongoClient(**connection_params)
 


### PR DESCRIPTION
# Description of change
This PR updates one of the keys according to the [PyMongo 4 Migration Guide](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#renamed-uri-options).

> Instead of ssl.CERT_NONE, ssl.CERT_OPTIONAL and ssl.CERT_REQUIRED, the new option expects a boolean value - True is equivalent to ssl.CERT_NONE, while False is equivalent to ssl.CERT_REQUIRED.

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
 - Low. This was a breaking change to PyMongo 3 and we should have done this in #99 
# Rollback steps
 - revert this branch, bump the version
