### PR TITLE
Gracefully handle the mongo server not supporting sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+  * Gracefully fallback to not using a session if sessions are not supported by the mongo server [#112](https://github.com/singer-io/tap-mongodb/pull/112)
+
 ## 3.1.0
   * Updates to run on python 3.11.7 [#111](https://github.com/singer-io/tap-mongodb/pull/111)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='3.1.0',
+      version='3.1.1',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -115,7 +115,7 @@ def maybe_get_session(client):
     that will work in the context manager
     '''
     try:
-        return client.start_session():
+        return client.start_session()
     except ConfigurationError:
         # log sessions not available
         LOGGER.info('Unable to start session, without session')


### PR DESCRIPTION
# Description of change
Some mongoDB servers are not supporting sessions. If they do not support sessions then gracefully revert to prior behavior without using a session and don't send the "keep-alive" message.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
