### PR TITLE
Update pylint disables March 2024

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_mongodb tap_mongodb/sync_strategies -d missing-docstring,fixme,duplicate-code,line-too-long,too-many-statements,too-many-locals,consider-using-f-string,consider-using-from-import,broad-exception-raised,superfluous-parens,consider-using-generator
+	pylint tap_mongodb tap_mongodb/sync_strategies -d missing-docstring,fixme,duplicate-code,line-too-long,too-many-statements,too-many-locals,consider-using-f-string,consider-using-from-import,broad-exception-raised,superfluous-parens,consider-using-generator,use-yield-from


### PR DESCRIPTION
# Description of change
Add use-yield-from to pylint disables list to allow build success

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
