### PR TITLE
Update  time_extracted

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "args": [
+        "--config",
+        "testing/confs/test1.json",
+        "--catalog",
+        "testing/cats/ship1.json",
+        "--state",
+        "testing/states/test1.json"
+      ],
+      "justMyCode": false
+    },
+    {
+      "name": "Python: Module",
+      "type": "python",
+      "request": "launch",
+      "module": "tap-mongodb",
+      "justMyCode": false,
+      "args": [
+        "--config",
+        "testing/confs/test1.json",
+        "--catalog",
+        "testing/cats/ship1.json",
+        "--state",
+        "testing/states/test1.json"
+      ]
+    }
+  ]
+}

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -102,7 +102,7 @@ def sync_collection(client, stream, state, projection):
                          projection,
                          sort=[("_id", pymongo.ASCENDING)]) as cursor:
         rows_saved = 0
-        time_extracted = utils.now()
+        
         start_time = time.time()
 
         schema = {"type": "object", "properties": {}}
@@ -121,7 +121,7 @@ def sync_collection(client, stream, state, projection):
             record_message = common.row_to_singer_record(stream,
                                                          row,
                                                          stream_version,
-                                                         time_extracted)
+                                                         utils.now())
 
             singer.write_message(record_message)
 

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -88,7 +88,7 @@ def sync_collection(client, stream, state, projection):
                          projection,
                          sort=[(replication_key_name, pymongo.ASCENDING)]) as cursor:
         rows_saved = 0
-        time_extracted = utils.now()
+        
         start_time = time.time()
 
         for row in cursor:
@@ -105,7 +105,7 @@ def sync_collection(client, stream, state, projection):
             record_message = common.row_to_singer_record(stream,
                                                          row,
                                                          stream_version,
-                                                         time_extracted)
+                                                          utils.now())
 
             # gen_schema = common.row_to_schema_message(schema, record_message.record, row)
             # if DeepDiff(schema, gen_schema, ignore_order=True) != {}:

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -123,7 +123,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
     )
     singer.write_message(activate_version_message)
 
-    time_extracted = utils.now()
+    
     rows_saved = 0
     start_time = time.time()
 
@@ -170,7 +170,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
                 record_message = common.row_to_singer_record(stream,
                                                              row['o'],
                                                              version,
-                                                             time_extracted)
+                                                              utils.now())
                 singer.write_message(record_message)
 
                 rows_saved += 1
@@ -191,7 +191,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
                 record_message = common.row_to_singer_record(stream,
                                                              row['o'],
                                                              version,
-                                                             time_extracted)
+                                                              utils.now())
                 singer.write_message(record_message)
 
                 rows_saved += 1
@@ -202,16 +202,19 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
 
             # flush buffer if it has filled up
             if len(update_buffer) >= MAX_UPDATE_BUFFER_LENGTH:
+                buffer_flush_time = None
                 for buffered_row in flush_buffer(client,
                                                  update_buffer,
                                                  stream_projection,
                                                  database_name,
                                                  collection_name):
+                    if not buffer_flush_time:
+                        buffer_flush_time = utils.now()
                     write_schema(schema, buffered_row, stream)
                     record_message = common.row_to_singer_record(stream,
                                                                  buffered_row,
                                                                  version,
-                                                                 time_extracted)
+                                                                 buffer_flush_time)
                     singer.write_message(record_message)
 
                     rows_saved += 1
@@ -229,7 +232,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
                     record_message = common.row_to_singer_record(stream,
                                                                  buffered_row,
                                                                  version,
-                                                                 time_extracted)
+                                                                  utils.now())
                     singer.write_message(record_message)
 
                     rows_saved += 1
@@ -248,7 +251,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
             record_message = common.row_to_singer_record(stream,
                                                          buffered_row,
                                                          version,
-                                                         time_extracted)
+                                                         utils.now())
 
             singer.write_message(record_message)
             rows_saved += 1

--- a/tap_mongodb/sync_strategies/oplog.py
+++ b/tap_mongodb/sync_strategies/oplog.py
@@ -132,6 +132,9 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
         'ns': {'$eq' : '{}.{}'.format(database_name, collection_name)}
     }
 
+    if (max_oplog_ts is not None):
+        oplog_query['ts']['$lte'] = max_oplog_ts
+
     projection = transform_projection(stream_projection)
 
     oplog_replay = stream_projection is None
@@ -163,6 +166,7 @@ def sync_collection(client, stream, state, stream_projection, max_oplog_ts=None)
 
             if row_op == 'i':
                 write_schema(schema, row['o'], stream)
+
                 record_message = common.row_to_singer_record(stream,
                                                              row['o'],
                                                              version,

--- a/testing/cats/ship1.json
+++ b/testing/cats/ship1.json
@@ -1,0 +1,59 @@
+{
+    "streams": [
+          {
+        "table_name": "Shipment",
+        "stream": "Shipment",
+        "metadata": [
+          {
+            "breadcrumb": [],
+            "metadata": {
+              "selected": true,
+              "replication-method": "LOG_BASED",
+              "tap-mongodb.projection": "{\"destination.data\":0,\"destination.destinationContact.attributes\":0,\"transferredItems.items.data\":0,\"reasignedItems.items.data\":0,\"customer.data\":0,\"reassignedItems.data\":0,\"items.data\":0,\"items.attributes\":0,\"canceledItems.modifiedReason.attributes\":0,\"canceledItems.data\":0,\"canceledItems.attributes\":0,\"rejectedItems.modifiedReason.attributes\":0,\"rejectedItems.data\":0,\"rejectedItems.attributes\":0,\"workflowState.taskList\":0,\"workflowState.attributes\":0,\"changeMessages\":0,\"attributes\":0,\"data\":0}",
+  
+              "table-key-properties": ["_id"],
+              "database-name": "fulfillment",
+              "row-count": 152644,
+              "is-view": false,
+              "valid-replication-keys": [
+                "orderId",
+                "originalOrderId",
+                "customerAccountId",
+                "tenantId",
+                "siteId",
+                "locationCode",
+                "workflowState.processInstanceId",
+                "packages._id",
+                "LastModifiedDate",
+                "fulfillmentLocationCode",
+                "lastModifiedDate",
+                "externalOrderId",
+                "_id",
+                "auditInfo.createDate",
+                "auditInfo.updateDate",
+                "items.auditInfo.updateDate",
+                "items.auditInfo.createDate",
+                "canceledItems.auditInfo.updateDate",
+                "canceledItems.auditInfo.createDate",
+                "reassignedItems.auditInfo.updateDate",
+                "reassignedItems.auditInfo.createDate",
+                "rejectedItems.auditInfo.updateDate",
+                "rejectedItems.auditInfo.createDate",
+                "transferredItems.auditInfo.updateDate",
+                "transferredItems.auditInfo.createDate",
+                "packages.auditInfo.updateDate",
+                "packages.auditInfo.createDate",
+                "workflowState.auditInfo.updateDate",
+                "workflowState.auditInfo.createDate"
+              ]
+            }
+          }
+        ],
+        "tap_stream_id": "fulfillment-Shipment",
+        "schema": {
+          "type": "object"
+        }
+      }
+    ]
+  }
+  

--- a/testing/cli_test.py
+++ b/testing/cli_test.py
@@ -1,0 +1,10 @@
+
+import sys
+ 
+# setting path
+sys.path.append('../tap_mongodb')
+ 
+# importing
+from tap_mongodb  import main_impl
+
+main_impl()

--- a/testing/confs/test1.json
+++ b/testing/confs/test1.json
@@ -1,0 +1,7 @@
+{
+    "password": "TBD",
+    "user": "TBD",
+    "host": "linuxdb.dev06.DEV.KIBOCOMMERCE.COM",
+    "port": "27000",
+    "database": "admin"
+  }

--- a/testing/states/test1.json
+++ b/testing/states/test1.json
@@ -1,0 +1,13 @@
+{
+  "bookmarks": {
+    
+    "fulfillment-Shipment": {
+      "last_replication_method": "LOG_BASED",
+      "oplog_ts_time": 1666265712,
+      "oplog_ts_inc": 4,
+      "version": 1661783871452,
+      "initial_full_table_complete": true
+    }
+  },
+  "currently_syncing": null
+}

--- a/testing/test1.sh
+++ b/testing/test1.sh
@@ -1,0 +1,6 @@
+tap-mongodb  \
+--config testing/confs/test1.json \
+--catalog testing/cats/ship1.json \
+--state testing/states/test1.json  > testing/res1.jsonl
+
+


### PR DESCRIPTION
This pull request includes changes to the oplog query in order to include the timestamp of the last change in the oplog from the beginning of the run. Additionally, the `time_extracted` variable has been updated to be the time of the query rather than the time of the start of the batch.