### PR TITLE
TDL-26885: Bump pymongo for veracode & dependabot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mongodb',
-      version='3.1.3',
+      version='3.1.4',
       description='Singer.io tap for extracting data from MongoDB',
       author='Stitch',
       url='https://singer.io',
@@ -11,7 +11,7 @@ setup(name='tap-mongodb',
       py_modules=['tap_mongodb'],
       install_requires=[
           'singer-python==6.0.0',
-          'pymongo==4.4.0',
+          'pymongo==4.10.1',
           'tzlocal==2.0.0',
       ],
       extras_require={


### PR DESCRIPTION
# Description of change
- Bumps pymongo to latest version (at time of writing) `4.10.1`
- Bumps tap version to `3.1.4`

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
