### PR TITLE
SAC-30745: Fix of handling inconsistent column length records

### DIFF
--- a/tests/test_mongodb_incremental.py
+++ b/tests/test_mongodb_incremental.py
@@ -97,7 +97,7 @@ class MongoDBIncremental(TestCase):
 
     def expected_last_sync_row_counts(self):
         return {
-            'simple_coll_1': 53, # 50 documents for initial insert, 2 documents inserted at the start of sync2 , 1 document which was updated at the end of sync 2. This is the last update before sync 3 so as part of historical sync this data is captured as well as in the log for log based replication
+            'simple_coll_1': 52, # 50 documents for initial insert, 2 documents inserted at the start of sync2
             'simple_coll_2': 102,
             **{"simple_coll_{}".format(k): 1 for k in self.key_names()}
         }

--- a/tests/test_mongodb_incremental.py
+++ b/tests/test_mongodb_incremental.py
@@ -467,6 +467,15 @@ class MongoDBIncremental(TestCase):
                                                                                    stream_catalog,
                                                                                    annotated_schema,
                                                                                    additional_md)
+        # Do an intentional write unrelated record before third sync 
+        #to allow LOG_BASED replication method to have a deterministic starting point for replication
+        with get_test_connection() as client:
+            # Write an unrelated oplog entry so LOG_BASED starts from a deterministic boundary.
+            client["oplog_anchor_db"]["oplog_anchor_coll"].insert_one({
+                "anchor": "third_sync_boundary",
+                "created_at": datetime.utcnow()
+            })
+
         # Run sync
         sync_job_name = runner.run_sync_mode(self, conn_id)
         exit_status = menagerie.get_exit_status(conn_id, sync_job_name)


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-30745

Changes:
Added a intentional write unrelated record before the 3rd sync to give the tap a clear bookmark so as to avoid any LOG BASED writes at an unpredictable point. That way the test stops to get random 52 or 53 at times, this becomes more deterministic

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
